### PR TITLE
Updated build to .NET 6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,7 +48,7 @@ dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
 ; Name all constant fields using PascalCase
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = warning
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds   = field
@@ -56,7 +56,7 @@ dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 ; Static fields should be _camelCase
-dotnet_naming_rule.static_fields_should_be_camel_case.severity = suggestion
+dotnet_naming_rule.static_fields_should_be_camel_case.severity = warning
 dotnet_naming_rule.static_fields_should_be_camel_case.symbols  = static_fields
 dotnet_naming_rule.static_fields_should_be_camel_case.style    = camel_case_underscore_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
@@ -64,7 +64,7 @@ dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
 
 ; Static readonly fields should be PascalCase
-dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
 dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols  = static_readonly_fields
 dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style    = pascal_case_style
 dotnet_naming_symbols.static_readonly_fields.applicable_kinds   = field
@@ -72,7 +72,7 @@ dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readon
 dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = private, internal, private_protected
 
 ; Internal and private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = warning
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
 dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
@@ -128,6 +128,7 @@ csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 
 # Other features
+csharp_style_namespace_declarations = file_scoped:suggestion
 csharp_style_prefer_index_operator = false:none
 csharp_style_prefer_range_operator = false:none
 csharp_style_pattern_local_over_anonymous_function = false:none

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Ignore revisions in git blame - set your git config to use the file by convention:
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Optional additional git config:
+# Mark any lines that have had a commit skipped using --ignore-rev with a `?`
+# git config --global blame.markIgnoredLines true
+# Mark any lines that were added in a skipped commit and can not be attributed with a `*`
+# git config --global blame.markUnblamableLines true
+
+# Convert to file-scoped namespaces.
+e646ad26bf2f484f8b9063d2d4d08a034027ff8e

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,12 @@
   "cSpell.words": [
     "autofac",
     "cref",
+    "cyclomatic",
+    "langword",
+    "listheader",
+    "paramref",
+    "seealso",
+    "typeparam",
     "xunit"
   ],
   "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,10 @@
 {
-  "dotnet-test-explorer.runInParallel": true,
-  "dotnet-test-explorer.testProjectPath": "test/**/*.Test.csproj",
+  "cSpell.words": [
+    "autofac",
+    "cref",
+    "xunit"
+  ],
+  "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,7 @@
     {
       "args": [
         "build",
+        "${workspaceFolder}/Autofac.Configuration.sln",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],
@@ -12,11 +13,32 @@
         "kind": "build"
       },
       "label": "build",
-      "presentation": {
-        "reveal": "silent"
-      },
       "problemMatcher": "$msCompile",
-      "type": "shell"
+      "type": "process"
+    },
+    {
+      "args": [
+        "test",
+        "${workspaceFolder}/Autofac.Configuration.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary",
+        "--results-directory",
+        "\"artifacts/coverage\"",
+        "--logger:trx",
+        "/p:CoverletOutput=\"${workspaceFolder}/artifacts/coverage/\"",
+        "/p:CollectCoverage=true",
+        "/p:CoverletOutputFormat=lcov",
+        "/p:Exclude=\"[System.*]*\"",
+        "-m:1"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "test"
+      },
+      "label": "test",
+      "problemMatcher": "$msCompile",
+      "type": "process"
     }
   ],
   "version": "2.0.0"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Autofac Project
+Copyright © 2014 Autofac Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,10 +2,89 @@
 
 Configuration support for [Autofac](https://autofac.org).
 
-[![Build status](https://ci.appveyor.com/api/projects/status/u6ujehy60pw4vyi2?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-configuration) [![Open in Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/autofac/Autofac.Configuration)
+[![Build status](https://ci.appveyor.com/api/projects/status/u6ujehy60pw4vyi2?svg=true)](https://ci.appveyor.com/project/Autofac/autofac-configuration)
 
-Please file issues and pull requests for this package in this repository rather than in the Autofac core repo.
+Please file issues and pull requests for this package [in this repository](https://github.com/autofac/Autofac.Configuration/issues) rather than in the Autofac core repo.
 
 - [Documentation](https://autofac.readthedocs.io/en/latest/configuration/xml.html)
 - [NuGet](https://www.nuget.org/packages/Autofac.Configuration)
 - [Contributing](https://autofac.readthedocs.io/en/latest/contributors.html)
+- [Open in Visual Studio Code](https://open.vscode.dev/autofac/Autofac.Configuration)
+
+## Quick Start
+
+The basic steps to getting configuration set up with your application are:
+
+1. Set up your configuration in JSON or XML files that can be read by `Microsoft.Extensions.Configuration`.
+   - JSON configuration uses `Microsoft.Extensions.Configuration.Json`
+   - XML configuration uses `Microsoft.Extensions.Configuration.Xml`
+2. Build the configuration using the `Microsoft.Extensions.Configuration.ConfigurationBuilder`.
+3. Create a new `Autofac.Configuration.ConfigurationModule` and pass the built `Microsoft.Extensions.Configuration.IConfiguration` into it.
+4. Register the `Autofac.Configuration.ConfigurationModule` with your container.
+
+A configuration file with some simple registrations looks like this:
+
+```json
+{
+  "defaultAssembly": "Autofac.Example.Calculator",
+  "components": [{
+    "type": "Autofac.Example.Calculator.Addition.Add, Autofac.Example.Calculator.Addition",
+    "services": [{
+      "type": "Autofac.Example.Calculator.Api.IOperation"
+    }],
+    "injectProperties": true
+  }, {
+    "type": "Autofac.Example.Calculator.Division.Divide, Autofac.Example.Calculator.Division",
+    "services": [{
+      "type": "Autofac.Example.Calculator.Api.IOperation"
+    }],
+    "parameters": {
+      "places": 4
+    }
+  }]
+}
+```
+
+JSON is cleaner and easier to read, but if you prefer XML, the same configuration looks like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<autofac defaultAssembly="Autofac.Example.Calculator">
+    <components name="0">
+        <type>Autofac.Example.Calculator.Addition.Add, Autofac.Example.Calculator.Addition</type>
+        <services name="0" type="Autofac.Example.Calculator.Api.IOperation" />
+        <injectProperties>true</injectProperties>
+    </components>
+    <components name="1">
+        <type>Autofac.Example.Calculator.Division.Divide, Autofac.Example.Calculator.Division</type>
+        <services name="0" type="Autofac.Example.Calculator.Api.IOperation" />
+        <injectProperties>true</injectProperties>
+        <parameters>
+            <places>4</places>
+        </parameters>
+    </components>
+</autofac>
+```
+
+*Note the ordinal "naming" of components and services in XML - this is due to the way Microsoft.Extensions.Configuration handles ordinal collections (arrays).*
+
+Build up your configuration and register it with the Autofac `ContainerBuilder` like this:
+
+```c#
+// Add the configuration to the ConfigurationBuilder.
+var config = new ConfigurationBuilder();
+// config.AddJsonFile comes from Microsoft.Extensions.Configuration.Json
+// config.AddXmlFile comes from Microsoft.Extensions.Configuration.Xml
+config.AddJsonFile("autofac.json");
+
+// Register the ConfigurationModule with Autofac.
+var module = new ConfigurationModule(config.Build());
+var builder = new ContainerBuilder();
+builder.RegisterModule(module);
+```
+
+Check out the [Autofac configuration documentation](https://autofac.readthedocs.io/en/latest/configuration/xml.html) for more information.
+
+## Get Help
+
+**Need help with Autofac?** We have [a documentation site](https://autofac.readthedocs.io/) as well as [API documentation](https://autofac.org/apidoc/). We're ready to answer your questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/autofac) or check out the [discussion forum](https://groups.google.com/forum/#forum/autofac).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 image: Ubuntu
 
-version: '6.0.0.{build}'
+version: "6.0.0.{build}"
 
 dotnet_csproj:
-  version_prefix: '6.0.0'
+  version_prefix: "6.0.0"
   patch: true
   file: 'src\**\*.csproj'
 
@@ -20,20 +20,20 @@ nuget:
 
 clone_depth: 1
 
-test: off
+test: false
 
 build_script:
   - pwsh: .\build.ps1
 
 artifacts:
-- path: artifacts\packages\**\*.nupkg
-  name: MyGet
+  - path: artifacts\packages\**\*.*nupkg
+    name: MyGet
+    type: NuGetPackage
 
 deploy:
-- provider: NuGet
-  server: https://www.myget.org/F/autofac/api/v2/package
-  api_key:
-    secure: xUXExgVAagrdEicCjSxsQVrwiLo2TtnfqMbYB9Cauq2cpbm/EVz957PBK0v/GEYq
-  skip_symbols: true
-  symbol_server: https://www.myget.org/F/autofac/symbols/api/v2/package
-  artifact: MyGet
+  - provider: NuGet
+    server: https://www.myget.org/F/autofac/api/v2/package
+    symbol_server: https://www.myget.org/F/autofac/api/v2/package
+    api_key:
+      secure: xUXExgVAagrdEicCjSxsQVrwiLo2TtnfqMbYB9Cauq2cpbm/EVz957PBK0v/GEYq
+    artifact: MyGet

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,10 @@ try {
 
     $artifactsPath = "$PSScriptRoot/artifacts"
     $packagesPath = "$artifactsPath/packages"
-    $sdkVersion = (Get-Content "$PSScriptRoot/global.json" | ConvertFrom-Json).sdk.version
+
+    $globalJson = (Get-Content "$PSScriptRoot/global.json" | ConvertFrom-Json -NoEnumerate);
+
+    $sdkVersion = $globalJson.sdk.version
 
     # Clean up artifacts folder
     if (Test-Path $artifactsPath) {
@@ -16,9 +19,18 @@ try {
         Remove-Item $artifactsPath -Force -Recurse
     }
 
-    # Install dotnet CLI
-    Write-Message "Installing .NET Core SDK version $sdkVersion"
-    Install-DotNetCli -Version $sdkVersion
+    # Install dotnet SDK versions during CI. In a local build we assume you have
+    # everything installed; on CI we'll force the install. If you install _any_
+    # SDKs, you have to install _all_ of them because you can't install SDKs in
+    # two different locations. dotnet CLI locates SDKs relative to the
+    # executable.
+    if ($Null -ne $env:APPVEYOR_BUILD_NUMBER) {
+        Install-DotNetCli -Version $sdkVersion
+        foreach ($additional in $globalJson.additionalSdks)
+        {
+            Install-DotNetCli -Version $additional;
+        }
+    }
 
     # Write out dotnet information
     & dotnet --info
@@ -42,6 +54,23 @@ try {
     Write-Message "Executing unit tests"
     Get-DotNetProjectDirectory -RootPath $PSScriptRoot\test | Invoke-Test
 
+
+    if ($env:CI -eq "true") {
+        # Generate Coverage Report
+        Write-Message "Downloading and verifying Codecov Uploader"
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri https://keybase.io/codecovsecurity/pgp_keys.asc -OutFile codecov.asc
+        gpg --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/linux/codecov -Outfile codecov
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/linux/codecov.SHA256SUM -Outfile codecov.SHA256SUM
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig -Outfile codecov.SHA256SUM.sig
+        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        shasum -a 256 -c codecov.SHA256SUM
+        chmod +x codecov
+
+        Write-Message "Generating Codecov Report"
+        & ./codecov -f "artifacts/coverage/*/coverage*.info"
+    }
 
     # Finished
     Write-Message "Build finished"

--- a/build/Autofac.Build.psm1
+++ b/build/Autofac.Build.psm1
@@ -1,47 +1,26 @@
-# EXIT CODES
+﻿# EXIT CODES
 # 1: dotnet packaging failure
 # 2: dotnet publishing failure
 # 3: Unit test failure
 # 4: dotnet / NuGet package restore failure
 
 <#
- .SYNOPSIS
-  Writes a build progress message to the host.
+.SYNOPSIS
+    Gets the set of directories in which projects are available for compile/processing.
 
- .PARAMETER Message
-  The message to write.
+.PARAMETER RootPath
+    Path where searching for project directories should begin.
 #>
-function Write-Message
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False, ValueFromPipelineByPropertyName=$False)]
-    [ValidateNotNullOrEmpty()]
-    [string]
-    $Message
-  )
+function Get-DotNetProjectDirectory {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False, ValueFromPipelineByPropertyName = $False)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $RootPath
+    )
 
-  Write-Host "[BUILD] $Message" -ForegroundColor Cyan
-}
-
-<#
- .SYNOPSIS
-  Gets the set of directories in which projects are available for compile/processing.
-
- .PARAMETER RootPath
-  Path where searching for project directories should begin.
-#>
-function Get-DotNetProjectDirectory
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False, ValueFromPipelineByPropertyName=$False)]
-    [ValidateNotNullOrEmpty()]
-    [string]
-    $RootPath
-  )
-
-  Get-ChildItem -Path $RootPath -Recurse -Include "*.csproj" | Select-Object @{ Name="ParentFolder"; Expression={ $_.Directory.FullName.TrimEnd("\") } } | Select-Object -ExpandProperty ParentFolder
+    Get-ChildItem -Path $RootPath -Recurse -Include "*.csproj" | Select-Object @{ Name = "ParentFolder"; Expression = { $_.Directory.FullName.TrimEnd("\") } } | Select-Object -ExpandProperty ParentFolder
 }
 
 <#
@@ -55,14 +34,7 @@ function Install-DotNetCli {
         [string]
         $Version = "Latest"
     )
-
-    if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue)) {
-        $installedVersion = dotnet --version
-        if ($installedVersion -eq $Version) {
-            Write-Message ".NET Core SDK version $Version is already installed"
-            return;
-        }
-    }
+    Write-Message "Installing .NET SDK version $Version"
 
     $callerPath = Split-Path $MyInvocation.PSCommandPath
     $installDir = Join-Path -Path $callerPath -ChildPath ".dotnet/cli"
@@ -77,15 +49,43 @@ function Install-DotNetCli {
         }
 
         & ./.dotnet/dotnet-install.ps1 -InstallDir "$installDir" -Version $Version
-        $env:PATH = "$installDir;$env:PATH"
     } else {
         if (!(Test-Path ./.dotnet/dotnet-install.sh)) {
             Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile "./.dotnet/dotnet-install.sh"
         }
 
         & bash ./.dotnet/dotnet-install.sh --install-dir "$installDir" --version $Version
-        $env:PATH = "$installDir`:$env:PATH"
     }
+
+    Add-Path "$installDir"
+}
+
+<#
+.SYNOPSIS
+    Appends a given value to the path but only if the value does not yet exist within the path.
+.PARAMETER Path
+    The path to append.
+#>
+function Add-Path {
+    [CmdletBinding()]
+    Param(
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Path
+    )
+
+    $pathSeparator = ":";
+
+    if ($IsWindows) {
+        $pathSeparator = ";";
+    }
+
+    $pathValues = $env:PATH.Split($pathSeparator);
+    if ($pathValues -Contains $Path) {
+      return;
+    }
+
+    $env:PATH = "${Path}${pathSeparator}$env:PATH"
 }
 
 <#
@@ -96,166 +96,161 @@ function Install-DotNetCli {
 .PARAMETER DirectoryName
     The path to the directory containing the project to build.
 #>
-function Invoke-DotNetBuild
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      & dotnet build ("""" + $Project.FullName + """") --configuration Release
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
+function Invoke-DotNetBuild {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            & dotnet build ("""" + $Project.FullName + """") --configuration Release
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+        }
     }
-  }
 }
 
 <#
- .SYNOPSIS
-  Invokes the dotnet utility to package a project.
+.SYNOPSIS
+    Invokes the dotnet utility to package a project.
 
- .PARAMETER ProjectDirectory
-  Path to the directory containing the project to package.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project to package.
 
- .PARAMETER PackagesPath
-  Path to the "artifacts\packages" folder where packages should go.
+.PARAMETER PackagesPath
+    Path to the "artifacts/packages" folder where packages should go.
 
- .PARAMETER VersionSuffix
-  The version suffix to use for the NuGet package version.
+.PARAMETER VersionSuffix
+    The version suffix to use for the NuGet package version.
 #>
-function Invoke-DotNetPack
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory,
+function Invoke-DotNetPack {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory,
 
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo]
-    $PackagesPath,
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo]
+        $PackagesPath,
 
-    [Parameter(Mandatory=$True, ValueFromPipeline=$False)]
-    [AllowEmptyString()]
-    [string]
-    $VersionSuffix = ""
-  )
-  Begin
-  {
-    New-Item -Path $PackagesPath -ItemType Directory -Force | Out-Null
-  }
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      if ($VersionSuffix -eq "")
-      {
-        & dotnet build ("""" + $Project.FullName + """") --configuration Release
-      }
-      else
-      {
-        & dotnet build ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix
-      }
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
-
-      if ($VersionSuffix -eq "")
-      {
-        & dotnet pack ("""" + $Project.FullName + """") --configuration Release --output $PackagesPath
-      }
-      else
-      {
-        & dotnet pack ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix --output $PackagesPath
-      }
-      if ($LASTEXITCODE -ne 0)
-      {
-        exit 1
-      }
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False)]
+        [AllowEmptyString()]
+        [string]
+        $VersionSuffix
+    )
+    Begin {
+        New-Item -Path $PackagesPath -ItemType Directory -Force | Out-Null
     }
-  }
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            if ($VersionSuffix -eq "") {
+                & dotnet build ("""" + $Project.FullName + """") --configuration Release
+            }
+            else {
+                & dotnet build ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix
+            }
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+
+            if ($VersionSuffix -eq "") {
+                & dotnet pack ("""" + $Project.FullName + """") --configuration Release --output $PackagesPath
+            }
+            else {
+                & dotnet pack ("""" + $Project.FullName + """") --configuration Release --version-suffix $VersionSuffix --output $PackagesPath
+            }
+            if ($LASTEXITCODE -ne 0) {
+                exit 1
+            }
+        }
+    }
 }
 
 <#
- .Synopsis
-  Invokes dotnet test command.
+.SYNOPSIS
+    Invokes dotnet test command.
 
- .Parameter ProjectDirectory
-  Path to the directory containing the project to package.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project to package.
 #>
-function Invoke-Test
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-      foreach($Project in $ProjectDirectory)
-      {
-          Push-Location $Project
+function Invoke-Test {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            Push-Location $Project
 
-          & dotnet test `
-            --configuration Release `
-            --logger:trx `
-            /p:CollectCoverage=true `
-            /p:CoverletOutput="..\..\" `
-            /p:MergeWith="..\..\coverage.json" `
-            /p:CoverletOutputFormat="json%2clcov" `
-            /p:ExcludeByAttribute=CompilerGeneratedAttribute `
-            /p:ExcludeByAttribute=GeneratedCodeAttribute
+            & dotnet test `
+                --configuration Release `
+                --logger:trx `
+                /p:CollectCoverage=true `
+                /p:CoverletOutput="../../artifacts/coverage/$($Project.Name)/" `
+                /p:CoverletOutputFormat="json%2clcov" `
+                /p:ExcludeByAttribute=CompilerGeneratedAttribute `
+                /p:ExcludeByAttribute=GeneratedCodeAttribute
 
+            if ($LASTEXITCODE -ne 0) {
+                Pop-Location
+                exit 3
+            }
 
-          if ($LASTEXITCODE -ne 0)
-          {
             Pop-Location
-            exit 3
-          }
-
-          Pop-Location
-      }
-  }
+        }
+    }
 }
 
 <#
- .SYNOPSIS
-  Restores dependencies using the dotnet utility.
+.SYNOPSIS
+    Restores dependencies using the dotnet utility.
 
- .PARAMETER ProjectDirectory
-  Path to the directory containing the project with dependencies to restore.
+.PARAMETER ProjectDirectory
+    Path to the directory containing the project with dependencies to restore.
 #>
-function Restore-DependencyPackages
-{
-  [CmdletBinding()]
-  Param(
-    [Parameter(Mandatory=$True, ValueFromPipeline=$True, ValueFromPipelineByPropertyName=$True)]
-    [ValidateNotNull()]
-    [System.IO.DirectoryInfo[]]
-    $ProjectDirectory
-  )
-  Process
-  {
-    foreach($Project in $ProjectDirectory)
-    {
-      & dotnet restore ("""" + $Project.FullName + """") --no-cache
-      if($LASTEXITCODE -ne 0)
-      {
-        exit 4
-      }
+function Restore-DependencyPackages {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True)]
+        [ValidateNotNull()]
+        [System.IO.DirectoryInfo[]]
+        $ProjectDirectory
+    )
+    Process {
+        foreach ($Project in $ProjectDirectory) {
+            & dotnet restore ("""" + $Project.FullName + """") --no-cache
+            if ($LASTEXITCODE -ne 0) {
+                exit 4
+            }
+        }
     }
-  }
+}
+
+<#
+.SYNOPSIS
+    Writes a build progress message to the host.
+
+.PARAMETER Message
+    The message to write.
+#>
+function Write-Message {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $True, ValueFromPipeline = $False, ValueFromPipelineByPropertyName = $False)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Message
+    )
+
+    Write-Host "[BUILD] $Message" -ForegroundColor Cyan
 }

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -4,11 +4,21 @@
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
     <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <Rule Id="CA1707" Action="None" />
     <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <Rule Id="CA1816" Action="None" />
+    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <Rule Id="CA1822" Action="None" />
+    <!-- Do not directly await a task - this is for libraries rather than test code. -->
+    <Rule Id="CA2007" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
+    <!-- Use Uri instead of string parameters - strings are easier for testing. -->
+    <Rule Id="CA2234" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
@@ -34,6 +44,10 @@
     <Rule Id="SA1309" Action="None" />
     <!-- Suppressions must have a justification -->
     <Rule Id="SA1404" Action="None" />
+    <!-- Elements should be documented -->
+    <Rule Id="SA1600" Action="None" />
+    <!-- Enuemration items should be documented -->
+    <Rule Id="SA1602" Action="None" />
     <!-- Parameter documentation must be in the right order -->
     <Rule Id="SA1612" Action="None" />
     <!-- Return value must be documented -->
@@ -46,5 +60,11 @@
     <Rule Id="SA1627" Action="None" />
     <!-- Enable XML documentation output-->
     <Rule Id="SA1652" Action="None" />
+    <!-- Private member is unused - tests for reflection require members that may not get used. -->
+    <Rule Id="IDE0051" Action="None" />
+    <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->
+    <Rule Id="IDE0052" Action="None" />
+    <!-- Remove unused parameter - tests for reflection require parameters that may not get used. -->
+    <Rule Id="IDE0060" Action="None" />
   </Rules>
 </RuleSet>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  branch: develop
+  require_ci_to_pass: yes
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
+    "version": "6.0.300",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Autofac.Configuration/Autofac.Configuration.csproj
+++ b/src/Autofac.Configuration/Autofac.Configuration.csproj
@@ -1,39 +1,56 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Description>Configuration support for Autofac.</Description>
     <!-- VersionPrefix patched by AppVeyor -->
     <VersionPrefix>0.0.1</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Assembly metadata -->
     <AssemblyName>Autofac.Configuration</AssemblyName>
+    <AssemblyTitle>Autofac.Configuration</AssemblyTitle>
+    <Description>Configuration support for Autofac.</Description>
+    <Copyright>Copyright © 2015 Autofac Contributors</Copyright>
+    <Authors>Autofac Contributors</Authors>
+    <Company>Autofac</Company>
+    <Product>Autofac</Product>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <!-- Frameworks and language features -->
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Packaging -->
     <PackageId>Autofac.Configuration</PackageId>
     <PackageTags>autofac;di;ioc;dependencyinjection</PackageTags>
     <PackageReleaseNotes>Release notes are at https://github.com/autofac/Autofac.Configuration/releases</PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://autofac.org</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/autofac/Autofac.Configuration</RepositoryUrl>
-    <AssemblyTitle>Autofac.Configuration</AssemblyTitle>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <Copyright>Copyright © 2015 Autofac Contributors</Copyright>
-    <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <ContinuousIntegrationBuild Condition="'$(CI)' != '' ">true</ContinuousIntegrationBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedAllSources>true</EmbedAllSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Features>IOperation</Features>
-    <Authors>Autofac Contributors</Authors>
-    <Company>Autofac</Company>
-    <Product>Autofac</Product>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
+  </ItemGroup>
+
+  <!-- Disable nullability warnings in netstandard2.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <NoWarn>$(NoWarn);8600;8601;8602;8603;8604</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="..\..\build\icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -42,19 +59,13 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
-      <PrivateAssets>All</PrivateAssets>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
-      <PrivateAssets>All</PrivateAssets>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Autofac.Configuration/ConfigurationModule.cs
+++ b/src/Autofac.Configuration/ConfigurationModule.cs
@@ -18,7 +18,7 @@ public class ConfigurationModule : Module
     /// An <see cref="IConfiguration"/> containing the definition for
     /// modules and components to register with the container.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
     public ConfigurationModule(IConfiguration configuration)
@@ -39,10 +39,10 @@ public class ConfigurationModule : Module
     /// Gets or sets the configuration registrar.
     /// </summary>
     /// <value>
-    /// An <see cref="Autofac.Configuration.IConfigurationRegistrar"/> that will be used as the
-    /// strategy for converting the <see cref="ConfigurationModule.Configuration"/>
+    /// An <see cref="IConfigurationRegistrar"/> that will be used as the
+    /// strategy for converting the <see cref="Configuration"/>
     /// into component registrations. If this value is <see langword="null" />, the registrar
-    /// will be a <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/>.
+    /// will be a <see cref="Core.ConfigurationRegistrar"/>.
     /// </value>
     public IConfigurationRegistrar? ConfigurationRegistrar { get; set; }
 
@@ -50,20 +50,20 @@ public class ConfigurationModule : Module
     /// Executes the conversion of configuration data into component registrations.
     /// </summary>
     /// <param name="builder">
-    /// The <see cref="Autofac.ContainerBuilder"/> into which registrations will be placed.
+    /// The <see cref="ContainerBuilder"/> into which registrations will be placed.
     /// </param>
     /// <remarks>
     /// <para>
-    /// This override uses the <see cref="ConfigurationModule.ConfigurationRegistrar"/>
-    /// to convert the <see cref="ConfigurationModule.Configuration"/>
+    /// This override uses the <see cref="ConfigurationRegistrar"/>
+    /// to convert the <see cref="Configuration"/>
     /// into component registrations in the provided <paramref name="builder" />.
     /// </para>
     /// <para>
-    /// If no specific <see cref="ConfigurationModule.ConfigurationRegistrar"/>
-    /// is set, the default <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/> type will be used.
+    /// If no specific <see cref="ConfigurationRegistrar"/>
+    /// is set, the default <see cref="Core.ConfigurationRegistrar"/> type will be used.
     /// </para>
     /// </remarks>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="builder" /> is <see langword="null" />.
     /// </exception>
     protected override void Load(ContainerBuilder builder)

--- a/src/Autofac.Configuration/ConfigurationModule.cs
+++ b/src/Autofac.Configuration/ConfigurationModule.cs
@@ -45,7 +45,7 @@ namespace Autofac.Configuration
         /// into component registrations. If this value is <see langword="null" />, the registrar
         /// will be a <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/>.
         /// </value>
-        public IConfigurationRegistrar ConfigurationRegistrar { get; set; }
+        public IConfigurationRegistrar? ConfigurationRegistrar { get; set; }
 
         /// <summary>
         /// Executes the conversion of configuration data into component registrations.

--- a/src/Autofac.Configuration/ConfigurationModule.cs
+++ b/src/Autofac.Configuration/ConfigurationModule.cs
@@ -4,77 +4,76 @@
 using Autofac.Configuration.Core;
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration
+namespace Autofac.Configuration;
+
+/// <summary>
+/// Module for configuration parsing and registration.
+/// </summary>
+public class ConfigurationModule : Module
 {
     /// <summary>
-    /// Module for configuration parsing and registration.
+    /// Initializes a new instance of the <see cref="ConfigurationModule"/> class.
     /// </summary>
-    public class ConfigurationModule : Module
+    /// <param name="configuration">
+    /// An <see cref="IConfiguration"/> containing the definition for
+    /// modules and components to register with the container.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    public ConfigurationModule(IConfiguration configuration)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurationModule"/> class.
-        /// </summary>
-        /// <param name="configuration">
-        /// An <see cref="IConfiguration"/> containing the definition for
-        /// modules and components to register with the container.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        public ConfigurationModule(IConfiguration configuration)
+        Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    /// <summary>
+    /// Gets the configuration to register.
+    /// </summary>
+    /// <value>
+    /// An <see cref="IConfiguration"/> containing the definition for
+    /// modules and components to register with the container.
+    /// </value>
+    public IConfiguration Configuration { get; private set; }
+
+    /// <summary>
+    /// Gets or sets the configuration registrar.
+    /// </summary>
+    /// <value>
+    /// An <see cref="Autofac.Configuration.IConfigurationRegistrar"/> that will be used as the
+    /// strategy for converting the <see cref="ConfigurationModule.Configuration"/>
+    /// into component registrations. If this value is <see langword="null" />, the registrar
+    /// will be a <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/>.
+    /// </value>
+    public IConfigurationRegistrar? ConfigurationRegistrar { get; set; }
+
+    /// <summary>
+    /// Executes the conversion of configuration data into component registrations.
+    /// </summary>
+    /// <param name="builder">
+    /// The <see cref="Autofac.ContainerBuilder"/> into which registrations will be placed.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// This override uses the <see cref="ConfigurationModule.ConfigurationRegistrar"/>
+    /// to convert the <see cref="ConfigurationModule.Configuration"/>
+    /// into component registrations in the provided <paramref name="builder" />.
+    /// </para>
+    /// <para>
+    /// If no specific <see cref="ConfigurationModule.ConfigurationRegistrar"/>
+    /// is set, the default <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/> type will be used.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="builder" /> is <see langword="null" />.
+    /// </exception>
+    protected override void Load(ContainerBuilder builder)
+    {
+        if (builder == null)
         {
-            Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            throw new ArgumentNullException(nameof(builder));
         }
 
-        /// <summary>
-        /// Gets the configuration to register.
-        /// </summary>
-        /// <value>
-        /// An <see cref="IConfiguration"/> containing the definition for
-        /// modules and components to register with the container.
-        /// </value>
-        public IConfiguration Configuration { get; private set; }
-
-        /// <summary>
-        /// Gets or sets the configuration registrar.
-        /// </summary>
-        /// <value>
-        /// An <see cref="Autofac.Configuration.IConfigurationRegistrar"/> that will be used as the
-        /// strategy for converting the <see cref="ConfigurationModule.Configuration"/>
-        /// into component registrations. If this value is <see langword="null" />, the registrar
-        /// will be a <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/>.
-        /// </value>
-        public IConfigurationRegistrar? ConfigurationRegistrar { get; set; }
-
-        /// <summary>
-        /// Executes the conversion of configuration data into component registrations.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="Autofac.ContainerBuilder"/> into which registrations will be placed.
-        /// </param>
-        /// <remarks>
-        /// <para>
-        /// This override uses the <see cref="ConfigurationModule.ConfigurationRegistrar"/>
-        /// to convert the <see cref="ConfigurationModule.Configuration"/>
-        /// into component registrations in the provided <paramref name="builder" />.
-        /// </para>
-        /// <para>
-        /// If no specific <see cref="ConfigurationModule.ConfigurationRegistrar"/>
-        /// is set, the default <see cref="Autofac.Configuration.Core.ConfigurationRegistrar"/> type will be used.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder" /> is <see langword="null" />.
-        /// </exception>
-        protected override void Load(ContainerBuilder builder)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            var registrar = ConfigurationRegistrar ?? new ConfigurationRegistrar();
-            registrar.RegisterConfiguration(builder, Configuration);
-        }
+        var registrar = ConfigurationRegistrar ?? new ConfigurationRegistrar();
+        registrar.RegisterConfiguration(builder, Configuration);
     }
 }

--- a/src/Autofac.Configuration/ConfigurationModule.cs
+++ b/src/Autofac.Configuration/ConfigurationModule.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Configuration.Core;
 using Microsoft.Extensions.Configuration;
 

--- a/src/Autofac.Configuration/Core/ComponentRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ComponentRegistrar.cs
@@ -20,15 +20,15 @@ public class ComponentRegistrar : IComponentRegistrar
     /// Registers individual configured components into a container builder.
     /// </summary>
     /// <param name="builder">
-    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
     /// </param>
     /// <param name="configuration">
     /// The <see cref="IConfiguration"/> containing the configured registrations.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if there is any issue in parsing the component configuration into registrations.
     /// </exception>
     /// <remarks>
@@ -85,7 +85,7 @@ public class ComponentRegistrar : IComponentRegistrar
     /// An <seealso cref="IEnumerable{T}"/> of <seealso cref="Service"/>
     /// objects associated with the <paramref name="component" />.
     /// </returns>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="component" /> is <see langword="null" />.
     /// </exception>
     protected virtual IEnumerable<Service> EnumerateComponentServices(IConfiguration component, Assembly? defaultAssembly)
@@ -132,7 +132,7 @@ public class ComponentRegistrar : IComponentRegistrar
     /// The default assembly, if any, from which unqualified type names
     /// should be resolved into types.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
     /// </exception>
     protected virtual void RegisterComponentMetadata<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
@@ -169,7 +169,7 @@ public class ComponentRegistrar : IComponentRegistrar
     /// <param name="registrar">
     /// The component registration to update with constructor parameter injection.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
     /// </exception>
     protected virtual void RegisterComponentParameters<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
@@ -206,7 +206,7 @@ public class ComponentRegistrar : IComponentRegistrar
     /// <param name="registrar">
     /// The component registration to update with property injection.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
     /// </exception>
     protected virtual void RegisterComponentProperties<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
@@ -247,7 +247,7 @@ public class ComponentRegistrar : IComponentRegistrar
     /// The default assembly, if any, from which unqualified type names
     /// should be resolved into types.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
     /// </exception>
     protected virtual void RegisterComponentServices<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
@@ -295,10 +295,10 @@ public class ComponentRegistrar : IComponentRegistrar
     /// You may override this method to extend the available grammar for auto activation settings.
     /// </para>
     /// </remarks>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if the value for <c>autoActivate</c> is not part of the
     /// recognized grammar.
     /// </exception>
@@ -367,10 +367,10 @@ public class ComponentRegistrar : IComponentRegistrar
     /// You may override this method to extend the available grammar for component ownership.
     /// </para>
     /// </remarks>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if the value for <c>ownership</c> is not part of the
     /// recognized grammar.
     /// </exception>
@@ -437,10 +437,10 @@ public class ComponentRegistrar : IComponentRegistrar
     /// You may override this method to extend the available grammar for property injection settings.
     /// </para>
     /// </remarks>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if the value for <c>injectProperties</c> is not part of the
     /// recognized grammar.
     /// </exception>
@@ -511,10 +511,10 @@ public class ComponentRegistrar : IComponentRegistrar
     /// You may override this method to extend the available grammar for lifetime scope.
     /// </para>
     /// </remarks>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if the value for lifetime scope is not part of the
     /// recognized grammar.
     /// </exception>

--- a/src/Autofac.Configuration/Core/ComponentRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ComponentRegistrar.cs
@@ -103,14 +103,7 @@ public class ComponentRegistrar : IComponentRegistrar
             // instead, it must be "key."
             var serviceType = serviceDefinition.GetType("type", defaultAssembly);
             string serviceKey = serviceDefinition["key"];
-            if (!string.IsNullOrEmpty(serviceKey))
-            {
-                yield return new KeyedService(serviceKey, serviceType);
-            }
-            else
-            {
-                yield return new TypedService(serviceType);
-            }
+            yield return !string.IsNullOrEmpty(serviceKey) ? new KeyedService(serviceKey, serviceType) : new TypedService(serviceType);
         }
     }
 

--- a/src/Autofac.Configuration/Core/ComponentRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ComponentRegistrar.cs
@@ -8,567 +8,566 @@ using Autofac.Configuration.Util;
 using Autofac.Core;
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration.Core
+namespace Autofac.Configuration.Core;
+
+/// <summary>
+/// Default component configuration processor.
+/// </summary>
+/// <seealso cref="IComponentRegistrar"/>
+public class ComponentRegistrar : IComponentRegistrar
 {
     /// <summary>
-    /// Default component configuration processor.
+    /// Registers individual configured components into a container builder.
     /// </summary>
-    /// <seealso cref="IComponentRegistrar"/>
-    public class ComponentRegistrar : IComponentRegistrar
+    /// <param name="builder">
+    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// </param>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> containing the configured registrations.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if there is any issue in parsing the component configuration into registrations.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This is where the individually configured component registrations get added to the <paramref name="builder"/>.
+    /// The <c>components</c> collection from the <paramref name="configuration"/>
+    /// get processed into individual registrations with associated lifetime scope, name, etc.
+    /// </para>
+    /// <para>
+    /// You may influence the process by overriding this whole method or by
+    /// overriding individual parsing subroutines in this registrar.
+    /// </para>
+    /// </remarks>
+    public virtual void RegisterConfiguredComponents(ContainerBuilder builder, IConfiguration configuration)
     {
-        /// <summary>
-        /// Registers individual configured components into a container builder.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
-        /// </param>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> containing the configured registrations.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if there is any issue in parsing the component configuration into registrations.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// This is where the individually configured component registrations get added to the <paramref name="builder"/>.
-        /// The <c>components</c> collection from the <paramref name="configuration"/>
-        /// get processed into individual registrations with associated lifetime scope, name, etc.
-        /// </para>
-        /// <para>
-        /// You may influence the process by overriding this whole method or by
-        /// overriding individual parsing subroutines in this registrar.
-        /// </para>
-        /// </remarks>
-        public virtual void RegisterConfiguredComponents(ContainerBuilder builder, IConfiguration configuration)
+        if (builder == null)
         {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            var defaultAssembly = configuration.DefaultAssembly();
-            foreach (var component in configuration.GetOrderedSubsections("components"))
-            {
-                var registrar = builder.RegisterType(component.GetType("type", defaultAssembly));
-                RegisterComponentServices(component, registrar, defaultAssembly);
-                RegisterComponentParameters(component, registrar);
-                RegisterComponentProperties(component, registrar);
-                RegisterComponentMetadata(component, registrar, defaultAssembly);
-                SetLifetimeScope(component, registrar);
-                SetComponentOwnership(component, registrar);
-                SetInjectProperties(component, registrar);
-                SetAutoActivate(component, registrar);
-            }
+            throw new ArgumentNullException(nameof(builder));
         }
 
-        /// <summary>
-        /// Reads configuration data for a component and enumerates the set
-        /// of configured services for the component.
-        /// </summary>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>services</c>
-        /// content will be read from this configuration object.
-        /// </param>
-        /// <param name="defaultAssembly">
-        /// The default assembly, if any, from which unqualified type names
-        /// should be resolved into types.
-        /// </param>
-        /// <returns>
-        /// An <seealso cref="IEnumerable{T}"/> of <seealso cref="Service"/>
-        /// objects associated with the <paramref name="component" />.
-        /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="component" /> is <see langword="null" />.
-        /// </exception>
-        protected virtual IEnumerable<Service> EnumerateComponentServices(IConfiguration component, Assembly? defaultAssembly)
+        if (configuration == null)
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
-
-            foreach (var serviceDefinition in component.GetOrderedSubsections("services"))
-            {
-                // "name" is a special reserved key in the XML configuration source
-                // that enables ordinal collections. To support both JSON and XML
-                // sources, we can't use "name" as the keyed service identifier;
-                // instead, it must be "key."
-                var serviceType = serviceDefinition.GetType("type", defaultAssembly);
-                string serviceKey = serviceDefinition["key"];
-                if (!string.IsNullOrEmpty(serviceKey))
-                {
-                    yield return new KeyedService(serviceKey, serviceType);
-                }
-                else
-                {
-                    yield return new TypedService(serviceType);
-                }
-            }
+            throw new ArgumentNullException(nameof(configuration));
         }
 
-        /// <summary>
-        /// Reads configuration data for a component's metadata
-        /// and updates the component registration as needed.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>metadata</c>
-        /// content will be read from this configuration object and used
-        /// as the metadata values.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration to update with metadata.
-        /// </param>
-        /// <param name="defaultAssembly">
-        /// The default assembly, if any, from which unqualified type names
-        /// should be resolved into types.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
-        /// </exception>
-        protected virtual void RegisterComponentMetadata<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        var defaultAssembly = configuration.DefaultAssembly();
+        foreach (var component in configuration.GetOrderedSubsections("components"))
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
+            var registrar = builder.RegisterType(component.GetType("type", defaultAssembly));
+            RegisterComponentServices(component, registrar, defaultAssembly);
+            RegisterComponentParameters(component, registrar);
+            RegisterComponentProperties(component, registrar);
+            RegisterComponentMetadata(component, registrar, defaultAssembly);
+            SetLifetimeScope(component, registrar);
+            SetComponentOwnership(component, registrar);
+            SetInjectProperties(component, registrar);
+            SetAutoActivate(component, registrar);
+        }
+    }
 
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            foreach (var ep in component.GetOrderedSubsections("metadata"))
-            {
-                registrar.WithMetadata(ep["key"], TypeManipulation.ChangeToCompatibleType(ep["value"], ep.GetType("type", defaultAssembly)));
-            }
+    /// <summary>
+    /// Reads configuration data for a component and enumerates the set
+    /// of configured services for the component.
+    /// </summary>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>services</c>
+    /// content will be read from this configuration object.
+    /// </param>
+    /// <param name="defaultAssembly">
+    /// The default assembly, if any, from which unqualified type names
+    /// should be resolved into types.
+    /// </param>
+    /// <returns>
+    /// An <seealso cref="IEnumerable{T}"/> of <seealso cref="Service"/>
+    /// objects associated with the <paramref name="component" />.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="component" /> is <see langword="null" />.
+    /// </exception>
+    protected virtual IEnumerable<Service> EnumerateComponentServices(IConfiguration component, Assembly? defaultAssembly)
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
         }
 
-        /// <summary>
-        /// Reads configuration data for a component's configured constructor parameter values
-        /// and updates the component registration as needed.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>parameters</c>
-        /// content will be read from this configuration object and used
-        /// as the properties to inject.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration to update with constructor parameter injection.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
-        /// </exception>
-        protected virtual void RegisterComponentParameters<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        foreach (var serviceDefinition in component.GetOrderedSubsections("services"))
         {
-            if (component == null)
+            // "name" is a special reserved key in the XML configuration source
+            // that enables ordinal collections. To support both JSON and XML
+            // sources, we can't use "name" as the keyed service identifier;
+            // instead, it must be "key."
+            var serviceType = serviceDefinition.GetType("type", defaultAssembly);
+            string serviceKey = serviceDefinition["key"];
+            if (!string.IsNullOrEmpty(serviceKey))
             {
-                throw new ArgumentNullException(nameof(component));
+                yield return new KeyedService(serviceKey, serviceType);
             }
-
-            if (registrar == null)
+            else
             {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            foreach (var param in component.GetParameters("parameters"))
-            {
-                registrar.WithParameter(param);
+                yield return new TypedService(serviceType);
             }
         }
+    }
 
-        /// <summary>
-        /// Reads configuration data for a component's configured property values
-        /// and updates the component registration as needed.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>properties</c>
-        /// content will be read from this configuration object and used
-        /// as the properties to inject.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration to update with property injection.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
-        /// </exception>
-        protected virtual void RegisterComponentProperties<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+    /// <summary>
+    /// Reads configuration data for a component's metadata
+    /// and updates the component registration as needed.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>metadata</c>
+    /// content will be read from this configuration object and used
+    /// as the metadata values.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration to update with metadata.
+    /// </param>
+    /// <param name="defaultAssembly">
+    /// The default assembly, if any, from which unqualified type names
+    /// should be resolved into types.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
+    /// </exception>
+    protected virtual void RegisterComponentMetadata<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
-
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            foreach (var prop in component.GetProperties("properties"))
-            {
-                registrar.WithProperty(prop);
-            }
+            throw new ArgumentNullException(nameof(component));
         }
 
-        /// <summary>
-        /// Reads configuration data for a component's exposed services
-        /// and updates the component registration as needed.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>services</c>
-        /// content will be read from this configuration object and used
-        /// as the services.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration to update with services.
-        /// </param>
-        /// <param name="defaultAssembly">
-        /// The default assembly, if any, from which unqualified type names
-        /// should be resolved into types.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
-        /// </exception>
-        protected virtual void RegisterComponentServices<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        if (registrar == null)
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
-
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            foreach (var service in EnumerateComponentServices(component, defaultAssembly))
-            {
-                registrar.As(service);
-            }
+            throw new ArgumentNullException(nameof(registrar));
         }
 
-        /// <summary>
-        /// Sets the auto activation mode for the component.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>autoActivate</c>
-        /// content will be read from this configuration object and used
-        /// to determine auto activation status.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration on which auto activation mode is being set.
-        /// </param>
-        /// <remarks>
-        /// <para>
-        /// By default, this implementation understands <see langword="null"/>, empty,
-        /// or <see langword="false"/> values (<c>false</c>, <c>0</c>, <c>no</c>)
-        /// to mean "not auto-activated" and <see langword="true"/>
-        /// values (<c>true</c>, <c>1</c>, <c>yes</c>) to mean auto activation
-        /// should occur.
-        /// </para>
-        /// <para>
-        /// You may override this method to extend the available grammar for auto activation settings.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if the value for <c>autoActivate</c> is not part of the
-        /// recognized grammar.
-        /// </exception>
-        protected virtual void SetAutoActivate<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        foreach (var ep in component.GetOrderedSubsections("metadata"))
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
+            registrar.WithMetadata(ep["key"], TypeManipulation.ChangeToCompatibleType(ep["value"], ep.GetType("type", defaultAssembly)));
+        }
+    }
 
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            if (component["autoActivate"].ToFlexibleBoolean())
-            {
-                registrar.AutoActivate();
-            }
+    /// <summary>
+    /// Reads configuration data for a component's configured constructor parameter values
+    /// and updates the component registration as needed.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>parameters</c>
+    /// content will be read from this configuration object and used
+    /// as the properties to inject.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration to update with constructor parameter injection.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
+    /// </exception>
+    protected virtual void RegisterComponentParameters<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
         }
 
-        /// <summary>
-        /// Sets the ownership model for the component.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>ownership</c>
-        /// content will be read from this configuration object and used
-        /// to determine component ownership.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration on which component ownership is being set.
-        /// </param>
-        /// <remarks>
-        /// <para>
-        /// By default, this implementation understands <see langword="null"/> or empty
-        /// values to be "default ownership model"; <c>lifetime-scope</c> or <c>LifetimeScope</c>
-        /// is "owned by lifetime scope"; and <c>external</c> or <c>ExternallyOwned</c> is
-        /// externally owned.
-        /// </para>
-        /// <para>
-        /// By default, this implementation understands the following grammar:
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Values</term>
-        /// <description>Lifetime Scope</description>
-        /// </listheader>
-        /// <item>
-        /// <term><see langword="null"/>, empty</term>
-        /// <description>Default - no specified ownership model</description>
-        /// </item>
-        /// <item>
-        /// <term><c>lifetime-scope</c>, <c>LifetimeScope</c></term>
-        /// <description>Owned by lifetime scope</description>
-        /// </item>
-        /// <item>
-        /// <term><c>external</c>, <c>ExternallyOwned</c></term>
-        /// <description>Externally owned</description>
-        /// </item>
-        /// </list>
-        /// <para>
-        /// You may override this method to extend the available grammar for component ownership.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if the value for <c>ownership</c> is not part of the
-        /// recognized grammar.
-        /// </exception>
-        [SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Do not need/want different code for ns2.1 vs ns2.0.")]
-        protected virtual void SetComponentOwnership<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        if (registrar == null)
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
-
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            string ownership = component["ownership"];
-            if (string.IsNullOrWhiteSpace(ownership))
-            {
-                return;
-            }
-
-            ownership = ownership.Trim().Replace("-", "");
-            if (ownership.Equals("lifetimescope", StringComparison.OrdinalIgnoreCase))
-            {
-                registrar.OwnedByLifetimeScope();
-                return;
-            }
-
-            if (ownership.Equals("external", StringComparison.OrdinalIgnoreCase) ||
-                ownership.Equals("externallyowned", StringComparison.OrdinalIgnoreCase))
-            {
-                registrar.ExternallyOwned();
-                return;
-            }
-
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.UnrecognisedOwnership, ownership));
+            throw new ArgumentNullException(nameof(registrar));
         }
 
-        /// <summary>
-        /// Sets the property injection mode for the component.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>injectProperties</c>
-        /// content will be read from this configuration object and used
-        /// to determine property injection status.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration on which the property injection mode is being set.
-        /// </param>
-        /// <remarks>
-        /// <para>
-        /// By default, this implementation understands <see langword="null"/>, empty,
-        /// or <see langword="false"/> values (<c>false</c>, <c>0</c>, <c>no</c>)
-        /// to mean "no property injection" and <see langword="true"/>
-        /// values (<c>true</c>, <c>1</c>, <c>yes</c>) to mean property injection
-        /// should occur.
-        /// </para>
-        /// <para>
-        /// You may override this method to extend the available grammar for property injection settings.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if the value for <c>injectProperties</c> is not part of the
-        /// recognized grammar.
-        /// </exception>
-        protected virtual void SetInjectProperties<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        foreach (var param in component.GetParameters("parameters"))
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
+            registrar.WithParameter(param);
+        }
+    }
 
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            if (component["injectProperties"].ToFlexibleBoolean())
-            {
-                registrar.PropertiesAutowired(PropertyWiringOptions.AllowCircularDependencies);
-            }
+    /// <summary>
+    /// Reads configuration data for a component's configured property values
+    /// and updates the component registration as needed.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>properties</c>
+    /// content will be read from this configuration object and used
+    /// as the properties to inject.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration to update with property injection.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
+    /// </exception>
+    protected virtual void RegisterComponentProperties<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
         }
 
-        /// <summary>
-        /// Sets the lifetime scope for the component.
-        /// </summary>
-        /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
-        /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
-        /// <param name="component">
-        /// The configuration data containing the component. The <c>instanceScope</c>
-        /// content will be read from this configuration object and used
-        /// as the lifetime scope.
-        /// </param>
-        /// <param name="registrar">
-        /// The component registration on which the lifetime scope is being set.
-        /// </param>
-        /// <remarks>
-        /// <para>
-        /// By default, this implementation understands the following grammar:
-        /// </para>
-        /// <list type="table">
-        /// <listheader>
-        /// <term>Values</term>
-        /// <description>Lifetime Scope</description>
-        /// </listheader>
-        /// <item>
-        /// <term><see langword="null"/>, empty</term>
-        /// <description>Default - no specified scope</description>
-        /// </item>
-        /// <item>
-        /// <term><c>single-instance</c>, <c>SingleInstance</c></term>
-        /// <description>Singleton</description>
-        /// </item>
-        /// <item>
-        /// <term><c>instance-per-lifetime-scope</c>, <c>InstancePerLifetimeScope</c>, <c>per-lifetime-scope</c>, <c>PerLifetimeScope</c></term>
-        /// <description>One instance per nested lifetime scope</description>
-        /// </item>
-        /// <item>
-        /// <term><c>instance-per-dependency</c>, <c>InstancePerDependency</c>, <c>per-dependency</c>, <c>PerDependency</c></term>
-        /// <description>One instance for each resolution call</description>
-        /// </item>
-        /// <item>
-        /// <term><c>instance-per-request</c>, <c>InstancePerRequest</c>, <c>per-request</c>, <c>PerRequest</c></term>
-        /// <description>One instance per request lifetime scope</description>
-        /// </item>
-        /// </list>
-        /// <para>
-        /// You may override this method to extend the available grammar for lifetime scope.
-        /// </para>
-        /// </remarks>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if the value for lifetime scope is not part of the
-        /// recognized grammar.
-        /// </exception>
-        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "The cyclomatic complexity is in extension methods. This method is actually pretty simple.")]
-        [SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Do not need/want different code for ns2.1 vs ns2.0.")]
-        protected virtual void SetLifetimeScope<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
-            where TReflectionActivatorData : ReflectionActivatorData
-            where TSingleRegistrationStyle : SingleRegistrationStyle
+        if (registrar == null)
         {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
-
-            if (registrar == null)
-            {
-                throw new ArgumentNullException(nameof(registrar));
-            }
-
-            string lifetimeScope = component["instanceScope"];
-            if (string.IsNullOrWhiteSpace(lifetimeScope))
-            {
-                return;
-            }
-
-            lifetimeScope = lifetimeScope.Trim().Replace("-", "");
-            if (lifetimeScope.Equals("singleinstance", StringComparison.OrdinalIgnoreCase))
-            {
-                registrar.SingleInstance();
-                return;
-            }
-
-            if (lifetimeScope.Equals("instanceperlifetimescope", StringComparison.OrdinalIgnoreCase) ||
-                lifetimeScope.Equals("perlifetimescope", StringComparison.OrdinalIgnoreCase))
-            {
-                registrar.InstancePerLifetimeScope();
-                return;
-            }
-
-            if (lifetimeScope.Equals("instanceperdependency", StringComparison.OrdinalIgnoreCase) ||
-                lifetimeScope.Equals("perdependency", StringComparison.OrdinalIgnoreCase))
-            {
-                registrar.InstancePerDependency();
-                return;
-            }
-
-            if (lifetimeScope.Equals("instanceperrequest", StringComparison.OrdinalIgnoreCase) ||
-                lifetimeScope.Equals("perrequest", StringComparison.OrdinalIgnoreCase))
-            {
-                registrar.InstancePerRequest();
-                return;
-            }
-
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.UnrecognisedScope, lifetimeScope));
+            throw new ArgumentNullException(nameof(registrar));
         }
+
+        foreach (var prop in component.GetProperties("properties"))
+        {
+            registrar.WithProperty(prop);
+        }
+    }
+
+    /// <summary>
+    /// Reads configuration data for a component's exposed services
+    /// and updates the component registration as needed.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>services</c>
+    /// content will be read from this configuration object and used
+    /// as the services.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration to update with services.
+    /// </param>
+    /// <param name="defaultAssembly">
+    /// The default assembly, if any, from which unqualified type names
+    /// should be resolved into types.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
+    /// </exception>
+    protected virtual void RegisterComponentServices<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
+        }
+
+        if (registrar == null)
+        {
+            throw new ArgumentNullException(nameof(registrar));
+        }
+
+        foreach (var service in EnumerateComponentServices(component, defaultAssembly))
+        {
+            registrar.As(service);
+        }
+    }
+
+    /// <summary>
+    /// Sets the auto activation mode for the component.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>autoActivate</c>
+    /// content will be read from this configuration object and used
+    /// to determine auto activation status.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration on which auto activation mode is being set.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// By default, this implementation understands <see langword="null"/>, empty,
+    /// or <see langword="false"/> values (<c>false</c>, <c>0</c>, <c>no</c>)
+    /// to mean "not auto-activated" and <see langword="true"/>
+    /// values (<c>true</c>, <c>1</c>, <c>yes</c>) to mean auto activation
+    /// should occur.
+    /// </para>
+    /// <para>
+    /// You may override this method to extend the available grammar for auto activation settings.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if the value for <c>autoActivate</c> is not part of the
+    /// recognized grammar.
+    /// </exception>
+    protected virtual void SetAutoActivate<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
+        }
+
+        if (registrar == null)
+        {
+            throw new ArgumentNullException(nameof(registrar));
+        }
+
+        if (component["autoActivate"].ToFlexibleBoolean())
+        {
+            registrar.AutoActivate();
+        }
+    }
+
+    /// <summary>
+    /// Sets the ownership model for the component.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>ownership</c>
+    /// content will be read from this configuration object and used
+    /// to determine component ownership.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration on which component ownership is being set.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// By default, this implementation understands <see langword="null"/> or empty
+    /// values to be "default ownership model"; <c>lifetime-scope</c> or <c>LifetimeScope</c>
+    /// is "owned by lifetime scope"; and <c>external</c> or <c>ExternallyOwned</c> is
+    /// externally owned.
+    /// </para>
+    /// <para>
+    /// By default, this implementation understands the following grammar:
+    /// </para>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Values</term>
+    /// <description>Lifetime Scope</description>
+    /// </listheader>
+    /// <item>
+    /// <term><see langword="null"/>, empty</term>
+    /// <description>Default - no specified ownership model</description>
+    /// </item>
+    /// <item>
+    /// <term><c>lifetime-scope</c>, <c>LifetimeScope</c></term>
+    /// <description>Owned by lifetime scope</description>
+    /// </item>
+    /// <item>
+    /// <term><c>external</c>, <c>ExternallyOwned</c></term>
+    /// <description>Externally owned</description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// You may override this method to extend the available grammar for component ownership.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if the value for <c>ownership</c> is not part of the
+    /// recognized grammar.
+    /// </exception>
+    [SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Do not need/want different code for ns2.1 vs ns2.0.")]
+    protected virtual void SetComponentOwnership<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
+        }
+
+        if (registrar == null)
+        {
+            throw new ArgumentNullException(nameof(registrar));
+        }
+
+        string ownership = component["ownership"];
+        if (string.IsNullOrWhiteSpace(ownership))
+        {
+            return;
+        }
+
+        ownership = ownership.Trim().Replace("-", "");
+        if (ownership.Equals("lifetimescope", StringComparison.OrdinalIgnoreCase))
+        {
+            registrar.OwnedByLifetimeScope();
+            return;
+        }
+
+        if (ownership.Equals("external", StringComparison.OrdinalIgnoreCase) ||
+            ownership.Equals("externallyowned", StringComparison.OrdinalIgnoreCase))
+        {
+            registrar.ExternallyOwned();
+            return;
+        }
+
+        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.UnrecognisedOwnership, ownership));
+    }
+
+    /// <summary>
+    /// Sets the property injection mode for the component.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>injectProperties</c>
+    /// content will be read from this configuration object and used
+    /// to determine property injection status.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration on which the property injection mode is being set.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// By default, this implementation understands <see langword="null"/>, empty,
+    /// or <see langword="false"/> values (<c>false</c>, <c>0</c>, <c>no</c>)
+    /// to mean "no property injection" and <see langword="true"/>
+    /// values (<c>true</c>, <c>1</c>, <c>yes</c>) to mean property injection
+    /// should occur.
+    /// </para>
+    /// <para>
+    /// You may override this method to extend the available grammar for property injection settings.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if the value for <c>injectProperties</c> is not part of the
+    /// recognized grammar.
+    /// </exception>
+    protected virtual void SetInjectProperties<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
+        }
+
+        if (registrar == null)
+        {
+            throw new ArgumentNullException(nameof(registrar));
+        }
+
+        if (component["injectProperties"].ToFlexibleBoolean())
+        {
+            registrar.PropertiesAutowired(PropertyWiringOptions.AllowCircularDependencies);
+        }
+    }
+
+    /// <summary>
+    /// Sets the lifetime scope for the component.
+    /// </summary>
+    /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
+    /// <typeparam name="TSingleRegistrationStyle">Registration style.</typeparam>
+    /// <param name="component">
+    /// The configuration data containing the component. The <c>instanceScope</c>
+    /// content will be read from this configuration object and used
+    /// as the lifetime scope.
+    /// </param>
+    /// <param name="registrar">
+    /// The component registration on which the lifetime scope is being set.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// By default, this implementation understands the following grammar:
+    /// </para>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Values</term>
+    /// <description>Lifetime Scope</description>
+    /// </listheader>
+    /// <item>
+    /// <term><see langword="null"/>, empty</term>
+    /// <description>Default - no specified scope</description>
+    /// </item>
+    /// <item>
+    /// <term><c>single-instance</c>, <c>SingleInstance</c></term>
+    /// <description>Singleton</description>
+    /// </item>
+    /// <item>
+    /// <term><c>instance-per-lifetime-scope</c>, <c>InstancePerLifetimeScope</c>, <c>per-lifetime-scope</c>, <c>PerLifetimeScope</c></term>
+    /// <description>One instance per nested lifetime scope</description>
+    /// </item>
+    /// <item>
+    /// <term><c>instance-per-dependency</c>, <c>InstancePerDependency</c>, <c>per-dependency</c>, <c>PerDependency</c></term>
+    /// <description>One instance for each resolution call</description>
+    /// </item>
+    /// <item>
+    /// <term><c>instance-per-request</c>, <c>InstancePerRequest</c>, <c>per-request</c>, <c>PerRequest</c></term>
+    /// <description>One instance per request lifetime scope</description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// You may override this method to extend the available grammar for lifetime scope.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="registrar"/> or <paramref name="component"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if the value for lifetime scope is not part of the
+    /// recognized grammar.
+    /// </exception>
+    [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "The cyclomatic complexity is in extension methods. This method is actually pretty simple.")]
+    [SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Do not need/want different code for ns2.1 vs ns2.0.")]
+    protected virtual void SetLifetimeScope<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar)
+        where TReflectionActivatorData : ReflectionActivatorData
+        where TSingleRegistrationStyle : SingleRegistrationStyle
+    {
+        if (component == null)
+        {
+            throw new ArgumentNullException(nameof(component));
+        }
+
+        if (registrar == null)
+        {
+            throw new ArgumentNullException(nameof(registrar));
+        }
+
+        string lifetimeScope = component["instanceScope"];
+        if (string.IsNullOrWhiteSpace(lifetimeScope))
+        {
+            return;
+        }
+
+        lifetimeScope = lifetimeScope.Trim().Replace("-", "");
+        if (lifetimeScope.Equals("singleinstance", StringComparison.OrdinalIgnoreCase))
+        {
+            registrar.SingleInstance();
+            return;
+        }
+
+        if (lifetimeScope.Equals("instanceperlifetimescope", StringComparison.OrdinalIgnoreCase) ||
+            lifetimeScope.Equals("perlifetimescope", StringComparison.OrdinalIgnoreCase))
+        {
+            registrar.InstancePerLifetimeScope();
+            return;
+        }
+
+        if (lifetimeScope.Equals("instanceperdependency", StringComparison.OrdinalIgnoreCase) ||
+            lifetimeScope.Equals("perdependency", StringComparison.OrdinalIgnoreCase))
+        {
+            registrar.InstancePerDependency();
+            return;
+        }
+
+        if (lifetimeScope.Equals("instanceperrequest", StringComparison.OrdinalIgnoreCase) ||
+            lifetimeScope.Equals("perrequest", StringComparison.OrdinalIgnoreCase))
+        {
+            registrar.InstancePerRequest();
+            return;
+        }
+
+        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.UnrecognisedScope, lifetimeScope));
     }
 }

--- a/src/Autofac.Configuration/Core/ComponentRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ComponentRegistrar.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Autofac.Builder;
 using Autofac.Configuration.Util;

--- a/src/Autofac.Configuration/Core/ComponentRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ComponentRegistrar.cs
@@ -92,7 +92,7 @@ namespace Autofac.Configuration.Core
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="component" /> is <see langword="null" />.
         /// </exception>
-        protected virtual IEnumerable<Service> EnumerateComponentServices(IConfiguration component, Assembly defaultAssembly)
+        protected virtual IEnumerable<Service> EnumerateComponentServices(IConfiguration component, Assembly? defaultAssembly)
         {
             if (component == null)
             {
@@ -139,7 +139,7 @@ namespace Autofac.Configuration.Core
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
         /// </exception>
-        protected virtual void RegisterComponentMetadata<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly defaultAssembly)
+        protected virtual void RegisterComponentMetadata<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
             where TReflectionActivatorData : ReflectionActivatorData
             where TSingleRegistrationStyle : SingleRegistrationStyle
         {
@@ -254,7 +254,7 @@ namespace Autofac.Configuration.Core
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="component" /> or <paramref name="registrar" /> is <see langword="null" />.
         /// </exception>
-        protected virtual void RegisterComponentServices<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly defaultAssembly)
+        protected virtual void RegisterComponentServices<TReflectionActivatorData, TSingleRegistrationStyle>(IConfiguration component, IRegistrationBuilder<object, TReflectionActivatorData, TSingleRegistrationStyle> registrar, Assembly? defaultAssembly)
             where TReflectionActivatorData : ReflectionActivatorData
             where TSingleRegistrationStyle : SingleRegistrationStyle
         {

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -182,21 +182,21 @@ public static class ConfigurationExtensions
     /// The <see cref="IConfiguration"/> object containing the type value to load.
     /// </param>
     /// <param name="key">
-    /// Name of the <see cref="System.Type"/> to load. This may be a partial type name or a fully-qualified type name.
+    /// Name of the <see cref="Type"/> to load. This may be a partial type name or a fully-qualified type name.
     /// </param>
     /// <param name="defaultAssembly">
-    /// The default <see cref="System.Reflection.Assembly"/> to use in type resolution if <paramref name="key"/>
+    /// The default <see cref="Assembly"/> to use in type resolution if <paramref name="key"/>
     /// is a partial type name.
     /// </param>
     /// <returns>
-    /// The resolved <see cref="System.Type"/> based on the specified name.
+    /// The resolved <see cref="Type"/> based on the specified name.
     /// </returns>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if the specified <paramref name="key"/> can't be resolved as a fully-qualified type name and
-    /// isn't a partial type name for a <see cref="System.Type"/> found in the <paramref name="defaultAssembly"/>.
+    /// isn't a partial type name for a <see cref="Type"/> found in the <paramref name="defaultAssembly"/>.
     /// </exception>
     public static Type GetType(this IConfiguration configuration, string key, Assembly? defaultAssembly)
     {
@@ -228,10 +228,10 @@ public static class ConfigurationExtensions
     /// <param name="configuration">The configuration item containing the list.</param>
     /// <param name="key">The subsection from which to get the ordered list of children.</param>
     /// <returns>The desired list of configuration subsections.</returns>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="configuration"/> or <paramref name="key"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if any of the subsections lack an  integer-valued <see cref="IConfigurationSection.Key"/>.
     /// </exception>
     internal static IEnumerable<IConfigurationSection> GetOrderedSubsections(this IConfiguration configuration, string key)

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -32,7 +32,7 @@ namespace Autofac.Configuration.Core
         /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
         /// </exception>
-        public static Assembly DefaultAssembly(this IConfiguration configuration)
+        public static Assembly? DefaultAssembly(this IConfiguration configuration)
         {
             return configuration.GetAssembly("defaultAssembly");
         }
@@ -58,7 +58,7 @@ namespace Autofac.Configuration.Core
         /// <exception cref="ArgumentException">
         /// Thrown if <paramref name="key"/> is empty or whitespace.
         /// </exception>
-        public static Assembly GetAssembly(this IConfiguration configuration, string key)
+        public static Assembly? GetAssembly(this IConfiguration configuration, string key)
         {
             if (configuration == null)
             {
@@ -166,16 +166,15 @@ namespace Autofac.Configuration.Core
                 string parameterName = GetKeyName(propertyElement.Key);
                 yield return new ResolvedParameter(
                     (pi, c) =>
-                {
-                    return pi.TryGetDeclaringProperty(out PropertyInfo prop) &&
-string.Equals(prop.Name, parameterName, StringComparison.OrdinalIgnoreCase);
-                },
+                    {
+                        return pi.TryGetDeclaringProperty(out PropertyInfo? prop) &&
+                            string.Equals(prop.Name, parameterName, StringComparison.OrdinalIgnoreCase);
+                    },
                     (pi, c) =>
-                {
-                    var prop = (PropertyInfo)null;
-                    pi.TryGetDeclaringProperty(out prop);
-                    return TypeManipulation.ChangeToCompatibleType(parameterValue, pi.ParameterType, prop);
-                });
+                    {
+                        pi.TryGetDeclaringProperty(out PropertyInfo? prop);
+                        return TypeManipulation.ChangeToCompatibleType(parameterValue, pi.ParameterType, prop!);
+                    });
             }
         }
 
@@ -202,7 +201,7 @@ string.Equals(prop.Name, parameterName, StringComparison.OrdinalIgnoreCase);
         /// Thrown if the specified <paramref name="key"/> can't be resolved as a fully-qualified type name and
         /// isn't a partial type name for a <see cref="System.Type"/> found in the <paramref name="defaultAssembly"/>.
         /// </exception>
-        public static Type GetType(this IConfiguration configuration, string key, Assembly defaultAssembly)
+        public static Type GetType(this IConfiguration configuration, string key, Assembly? defaultAssembly)
         {
             if (configuration == null)
             {

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -73,12 +73,7 @@ public static class ConfigurationExtensions
         }
 
         string assemblyName = configuration[key];
-        if (string.IsNullOrWhiteSpace(assemblyName))
-        {
-            return null;
-        }
-
-        return Assembly.Load(new AssemblyName(assemblyName));
+        return string.IsNullOrWhiteSpace(assemblyName) ? null : Assembly.Load(new AssemblyName(assemblyName));
     }
 
     /// <summary>
@@ -214,12 +209,9 @@ public static class ConfigurationExtensions
             type = defaultAssembly.GetType(typeName, false, true);
         }
 
-        if (type == null)
-        {
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, typeName));
-        }
-
-        return type;
+        return type == null
+            ? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, typeName))
+            : type;
     }
 
     /// <summary>
@@ -249,14 +241,9 @@ public static class ConfigurationExtensions
         var configurationSection = configuration.GetSection(key);
         foreach (var section in configurationSection.GetChildren())
         {
-            if (int.TryParse(section.Key, out var _))
-            {
-                yield return section;
-            }
-            else
-            {
-                throw new InvalidOperationException(ConfigurationResources.FormatCollectionMustBeOrderedByName(key, configurationSection.Path));
-            }
+            yield return int.TryParse(section.Key, out var _)
+                ? section
+                : throw new InvalidOperationException(ConfigurationResources.FormatCollectionMustBeOrderedByName(key, configurationSection.Path));
         }
     }
 
@@ -338,11 +325,6 @@ public static class ConfigurationExtensions
     private static string GetKeyName(string fullKey)
     {
         int index = fullKey.LastIndexOf(':');
-        if (index < 0)
-        {
-            return fullKey;
-        }
-
-        return fullKey.Substring(index + 1);
+        return index < 0 ? fullKey : fullKey.Substring(index + 1);
     }
 }

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -7,343 +7,342 @@ using Autofac.Configuration.Util;
 using Autofac.Core;
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration.Core
+namespace Autofac.Configuration.Core;
+
+/// <summary>
+/// Extension methods for working with <see cref="IConfiguration"/>.
+/// </summary>
+public static class ConfigurationExtensions
 {
     /// <summary>
-    /// Extension methods for working with <see cref="IConfiguration"/>.
+    /// Reads the default assembly information from configuration and
+    /// parses the assembly name into an assembly.
     /// </summary>
-    public static class ConfigurationExtensions
+    /// <param name="configuration">
+    /// An <see cref="IConfiguration"/> from which the default assembly
+    /// should be read.
+    /// </param>
+    /// <returns>
+    /// An <see cref="Assembly"/> if the default assembly is specified on
+    /// <paramref name="configuration"/>; or <see langword="null"/> if not.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    public static Assembly? DefaultAssembly(this IConfiguration configuration)
     {
-        /// <summary>
-        /// Reads the default assembly information from configuration and
-        /// parses the assembly name into an assembly.
-        /// </summary>
-        /// <param name="configuration">
-        /// An <see cref="IConfiguration"/> from which the default assembly
-        /// should be read.
-        /// </param>
-        /// <returns>
-        /// An <see cref="Assembly"/> if the default assembly is specified on
-        /// <paramref name="configuration"/>; or <see langword="null"/> if not.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        public static Assembly? DefaultAssembly(this IConfiguration configuration)
+        return configuration.GetAssembly("defaultAssembly");
+    }
+
+    /// <summary>
+    /// Reads an assembly name from configuration and parses the assembly name into an assembly.
+    /// </summary>
+    /// <param name="configuration">
+    /// An <see cref="IConfiguration"/> from which the default assembly
+    /// should be read.
+    /// </param>
+    /// <param name="key">
+    /// The <see cref="string"/> key in configuration where the assembly name
+    /// is specified.
+    /// </param>
+    /// <returns>
+    /// An <see cref="Assembly"/> if the assembly is specified on
+    /// <paramref name="configuration"/>; or <see langword="null"/> if not.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="configuration"/> or <paramref name="key"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="key"/> is empty or whitespace.
+    /// </exception>
+    public static Assembly? GetAssembly(this IConfiguration configuration, string key)
+    {
+        if (configuration == null)
         {
-            return configuration.GetAssembly("defaultAssembly");
+            throw new ArgumentNullException(nameof(configuration));
         }
 
-        /// <summary>
-        /// Reads an assembly name from configuration and parses the assembly name into an assembly.
-        /// </summary>
-        /// <param name="configuration">
-        /// An <see cref="IConfiguration"/> from which the default assembly
-        /// should be read.
-        /// </param>
-        /// <param name="key">
-        /// The <see cref="string"/> key in configuration where the assembly name
-        /// is specified.
-        /// </param>
-        /// <returns>
-        /// An <see cref="Assembly"/> if the assembly is specified on
-        /// <paramref name="configuration"/>; or <see langword="null"/> if not.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="configuration"/> or <paramref name="key"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// Thrown if <paramref name="key"/> is empty or whitespace.
-        /// </exception>
-        public static Assembly? GetAssembly(this IConfiguration configuration, string key)
+        if (key == null)
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (string.IsNullOrWhiteSpace(key))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.ArgumentMayNotBeEmpty, "configuration key"), nameof(key));
-            }
-
-            string assemblyName = configuration[key];
-            if (string.IsNullOrWhiteSpace(assemblyName))
-            {
-                return null;
-            }
-
-            return Assembly.Load(new AssemblyName(assemblyName));
+            throw new ArgumentNullException(nameof(key));
         }
 
-        /// <summary>
-        /// Converts configured parameter values into parameters that can be used
-        /// during object resolution.
-        /// </summary>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> element that contains the component
-        /// with defined parameters.
-        /// </param>
-        /// <param name="key">
-        /// The <see cref="string"/> key indicating the sub-element with the
-        /// parameters. Usually this is <c>parameters</c>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IEnumerable{T}"/> of <see cref="Parameter"/> values
-        /// that can be used during object resolution.
-        /// </returns>
-        public static IEnumerable<Parameter> GetParameters(this IConfiguration configuration, string key)
+        if (string.IsNullOrWhiteSpace(key))
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (string.IsNullOrWhiteSpace(key))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.ArgumentMayNotBeEmpty, "configuration key"), nameof(key));
-            }
-
-            foreach (var parameterElement in configuration.GetSection(key).GetChildren())
-            {
-                var parameterValue = GetConfiguredParameterValue(parameterElement);
-                string parameterName = GetKeyName(parameterElement.Key);
-                yield return new ResolvedParameter(
-                    (pi, c) => string.Equals(pi.Name, parameterName, StringComparison.OrdinalIgnoreCase),
-                    (pi, c) => TypeManipulation.ChangeToCompatibleType(parameterValue, pi.ParameterType, pi));
-            }
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.ArgumentMayNotBeEmpty, "configuration key"), nameof(key));
         }
 
-        /// <summary>
-        /// Converts configured property values into parameters that can be used
-        /// during object resolution.
-        /// </summary>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> element that contains the component
-        /// with defined properties.
-        /// </param>
-        /// <param name="key">
-        /// The <see cref="string"/> key indicating the sub-element with the
-        /// propeties. Usually this is <c>properties</c>.
-        /// </param>
-        /// <returns>
-        /// An <see cref="IEnumerable{T}"/> of <see cref="Parameter"/> values
-        /// that can be used during object resolution.
-        /// </returns>
-        public static IEnumerable<Parameter> GetProperties(this IConfiguration configuration, string key)
+        string assemblyName = configuration[key];
+        if (string.IsNullOrWhiteSpace(assemblyName))
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (string.IsNullOrWhiteSpace(key))
-            {
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.ArgumentMayNotBeEmpty, "configuration key"), nameof(key));
-            }
-
-            foreach (var propertyElement in configuration.GetSection(key).GetChildren())
-            {
-                var parameterValue = GetConfiguredParameterValue(propertyElement);
-                string parameterName = GetKeyName(propertyElement.Key);
-                yield return new ResolvedParameter(
-                    (pi, c) =>
-                    {
-                        return pi.TryGetDeclaringProperty(out PropertyInfo? prop) &&
-                            string.Equals(prop.Name, parameterName, StringComparison.OrdinalIgnoreCase);
-                    },
-                    (pi, c) =>
-                    {
-                        pi.TryGetDeclaringProperty(out PropertyInfo? prop);
-                        return TypeManipulation.ChangeToCompatibleType(parameterValue, pi.ParameterType, prop!);
-                    });
-            }
+            return null;
         }
 
-        /// <summary>
-        /// Loads a type by name.
-        /// </summary>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> object containing the type value to load.
-        /// </param>
-        /// <param name="key">
-        /// Name of the <see cref="System.Type"/> to load. This may be a partial type name or a fully-qualified type name.
-        /// </param>
-        /// <param name="defaultAssembly">
-        /// The default <see cref="System.Reflection.Assembly"/> to use in type resolution if <paramref name="key"/>
-        /// is a partial type name.
-        /// </param>
-        /// <returns>
-        /// The resolved <see cref="System.Type"/> based on the specified name.
-        /// </returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if the specified <paramref name="key"/> can't be resolved as a fully-qualified type name and
-        /// isn't a partial type name for a <see cref="System.Type"/> found in the <paramref name="defaultAssembly"/>.
-        /// </exception>
-        public static Type GetType(this IConfiguration configuration, string key, Assembly? defaultAssembly)
+        return Assembly.Load(new AssemblyName(assemblyName));
+    }
+
+    /// <summary>
+    /// Converts configured parameter values into parameters that can be used
+    /// during object resolution.
+    /// </summary>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> element that contains the component
+    /// with defined parameters.
+    /// </param>
+    /// <param name="key">
+    /// The <see cref="string"/> key indicating the sub-element with the
+    /// parameters. Usually this is <c>parameters</c>.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> of <see cref="Parameter"/> values
+    /// that can be used during object resolution.
+    /// </returns>
+    public static IEnumerable<Parameter> GetParameters(this IConfiguration configuration, string key)
+    {
+        if (configuration == null)
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            string typeName = configuration[key];
-            var type = Type.GetType(typeName);
-
-            if (type == null && defaultAssembly != null)
-            {
-                // Don't throw on error; we'll check it later.
-                type = defaultAssembly.GetType(typeName, false, true);
-            }
-
-            if (type == null)
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, typeName));
-            }
-
-            return type;
+            throw new ArgumentNullException(nameof(configuration));
         }
 
-        /// <summary>
-        /// Gets an ordered list of child configuration sections.
-        /// </summary>
-        /// <param name="configuration">The configuration item containing the list.</param>
-        /// <param name="key">The subsection from which to get the ordered list of children.</param>
-        /// <returns>The desired list of configuration subsections.</returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="configuration"/> or <paramref name="key"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if any of the subsections lack an  integer-valued <see cref="IConfigurationSection.Key"/>.
-        /// </exception>
-        internal static IEnumerable<IConfigurationSection> GetOrderedSubsections(this IConfiguration configuration, string key)
+        if (key == null)
         {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
+            throw new ArgumentNullException(nameof(key));
+        }
 
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.ArgumentMayNotBeEmpty, "configuration key"), nameof(key));
+        }
 
-            var configurationSection = configuration.GetSection(key);
-            foreach (var section in configurationSection.GetChildren())
-            {
-                if (int.TryParse(section.Key, out var _))
+        foreach (var parameterElement in configuration.GetSection(key).GetChildren())
+        {
+            var parameterValue = GetConfiguredParameterValue(parameterElement);
+            string parameterName = GetKeyName(parameterElement.Key);
+            yield return new ResolvedParameter(
+                (pi, c) => string.Equals(pi.Name, parameterName, StringComparison.OrdinalIgnoreCase),
+                (pi, c) => TypeManipulation.ChangeToCompatibleType(parameterValue, pi.ParameterType, pi));
+        }
+    }
+
+    /// <summary>
+    /// Converts configured property values into parameters that can be used
+    /// during object resolution.
+    /// </summary>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> element that contains the component
+    /// with defined properties.
+    /// </param>
+    /// <param name="key">
+    /// The <see cref="string"/> key indicating the sub-element with the
+    /// propeties. Usually this is <c>properties</c>.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> of <see cref="Parameter"/> values
+    /// that can be used during object resolution.
+    /// </returns>
+    public static IEnumerable<Parameter> GetProperties(this IConfiguration configuration, string key)
+    {
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.ArgumentMayNotBeEmpty, "configuration key"), nameof(key));
+        }
+
+        foreach (var propertyElement in configuration.GetSection(key).GetChildren())
+        {
+            var parameterValue = GetConfiguredParameterValue(propertyElement);
+            string parameterName = GetKeyName(propertyElement.Key);
+            yield return new ResolvedParameter(
+                (pi, c) =>
                 {
-                    yield return section;
-                }
-                else
+                    return pi.TryGetDeclaringProperty(out PropertyInfo? prop) &&
+                        string.Equals(prop.Name, parameterName, StringComparison.OrdinalIgnoreCase);
+                },
+                (pi, c) =>
                 {
-                    throw new InvalidOperationException(ConfigurationResources.FormatCollectionMustBeOrderedByName(key, configurationSection.Path));
-                }
-            }
+                    pi.TryGetDeclaringProperty(out PropertyInfo? prop);
+                    return TypeManipulation.ChangeToCompatibleType(parameterValue, pi.ParameterType, prop!);
+                });
+        }
+    }
+
+    /// <summary>
+    /// Loads a type by name.
+    /// </summary>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> object containing the type value to load.
+    /// </param>
+    /// <param name="key">
+    /// Name of the <see cref="System.Type"/> to load. This may be a partial type name or a fully-qualified type name.
+    /// </param>
+    /// <param name="defaultAssembly">
+    /// The default <see cref="System.Reflection.Assembly"/> to use in type resolution if <paramref name="key"/>
+    /// is a partial type name.
+    /// </param>
+    /// <returns>
+    /// The resolved <see cref="System.Type"/> based on the specified name.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if the specified <paramref name="key"/> can't be resolved as a fully-qualified type name and
+    /// isn't a partial type name for a <see cref="System.Type"/> found in the <paramref name="defaultAssembly"/>.
+    /// </exception>
+    public static Type GetType(this IConfiguration configuration, string key, Assembly? defaultAssembly)
+    {
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
         }
 
-        /// <summary>
-        /// Inspects a parameter/property value to determine if it's a scalar,
-        /// list, or dictionary property and casts it appropriately.
-        /// </summary>
-        /// <param name="value">
-        /// The <see cref="IConfigurationSection"/> object containing the parameter/property
-        /// value to parse.
-        /// </param>
-        /// <returns>
-        /// A value that can be type-converted and used during object resolution.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// The Microsoft configuration model code sees arrays (lists) the same
-        /// as a dictionary with numeric keys. We have to do some work to determine
-        /// how to store the parsed configuration values so they can be converted
-        /// appropriately at resolve time; and there's still an edge case where
-        /// someone actually wanted a <see cref="Dictionary{TKey, TValue}"/> with
-        /// sequential, zero-based numeric keys.
-        /// </para>
-        /// </remarks>
-        private static object GetConfiguredParameterValue(IConfigurationSection value)
+        string typeName = configuration[key];
+        var type = Type.GetType(typeName);
+
+        if (type == null && defaultAssembly != null)
         {
-            var subKeys = value.GetChildren().Select(sk => new Tuple<string, string>(GetKeyName(sk.Key), sk.Value)).ToArray();
-            if (subKeys.Length == 0)
+            // Don't throw on error; we'll check it later.
+            type = defaultAssembly.GetType(typeName, false, true);
+        }
+
+        if (type == null)
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, typeName));
+        }
+
+        return type;
+    }
+
+    /// <summary>
+    /// Gets an ordered list of child configuration sections.
+    /// </summary>
+    /// <param name="configuration">The configuration item containing the list.</param>
+    /// <param name="key">The subsection from which to get the ordered list of children.</param>
+    /// <returns>The desired list of configuration subsections.</returns>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="configuration"/> or <paramref name="key"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if any of the subsections lack an  integer-valued <see cref="IConfigurationSection.Key"/>.
+    /// </exception>
+    internal static IEnumerable<IConfigurationSection> GetOrderedSubsections(this IConfiguration configuration, string key)
+    {
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        if (key == null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        var configurationSection = configuration.GetSection(key);
+        foreach (var section in configurationSection.GetChildren())
+        {
+            if (int.TryParse(section.Key, out var _))
             {
-                // No subkeys indicates a scalar value.
-                return value.Value;
+                yield return section;
             }
-
-            if (subKeys.All(sk => int.TryParse(sk.Item1, out int parsed)))
+            else
             {
-                int i = 0;
-                bool isList = true;
-                foreach (int subKey in subKeys.Select(sk => int.Parse(sk.Item1, CultureInfo.InvariantCulture)))
-                {
-                    if (subKey != i)
-                    {
-                        isList = false;
-                        break;
-                    }
+                throw new InvalidOperationException(ConfigurationResources.FormatCollectionMustBeOrderedByName(key, configurationSection.Path));
+            }
+        }
+    }
 
-                    i++;
+    /// <summary>
+    /// Inspects a parameter/property value to determine if it's a scalar,
+    /// list, or dictionary property and casts it appropriately.
+    /// </summary>
+    /// <param name="value">
+    /// The <see cref="IConfigurationSection"/> object containing the parameter/property
+    /// value to parse.
+    /// </param>
+    /// <returns>
+    /// A value that can be type-converted and used during object resolution.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The Microsoft configuration model code sees arrays (lists) the same
+    /// as a dictionary with numeric keys. We have to do some work to determine
+    /// how to store the parsed configuration values so they can be converted
+    /// appropriately at resolve time; and there's still an edge case where
+    /// someone actually wanted a <see cref="Dictionary{TKey, TValue}"/> with
+    /// sequential, zero-based numeric keys.
+    /// </para>
+    /// </remarks>
+    private static object GetConfiguredParameterValue(IConfigurationSection value)
+    {
+        var subKeys = value.GetChildren().Select(sk => new Tuple<string, string>(GetKeyName(sk.Key), sk.Value)).ToArray();
+        if (subKeys.Length == 0)
+        {
+            // No subkeys indicates a scalar value.
+            return value.Value;
+        }
+
+        if (subKeys.All(sk => int.TryParse(sk.Item1, out int parsed)))
+        {
+            int i = 0;
+            bool isList = true;
+            foreach (int subKey in subKeys.Select(sk => int.Parse(sk.Item1, CultureInfo.InvariantCulture)))
+            {
+                if (subKey != i)
+                {
+                    isList = false;
+                    break;
                 }
 
-                if (isList)
+                i++;
+            }
+
+            if (isList)
+            {
+                var list = new List<string>();
+                foreach (var subKey in subKeys)
                 {
-                    var list = new List<string>();
-                    foreach (var subKey in subKeys)
-                    {
-                        list.Add(subKey.Item2);
-                    }
-
-                    return new ConfiguredListParameter { List = list.ToArray() };
+                    list.Add(subKey.Item2);
                 }
-            }
 
-            // There are subkeys but not all zero-based sequential numbers - it's a dictionary.
-            var dict = new Dictionary<string, string>();
-            foreach (var subKey in subKeys)
-            {
-                dict[subKey.Item1] = subKey.Item2;
+                return new ConfiguredListParameter { List = list.ToArray() };
             }
-
-            return new ConfiguredDictionaryParameter { Dictionary = dict };
         }
 
-        /// <summary>
-        /// Gets the simple configuration key name from a full, colon-delimited
-        /// configuration key name.
-        /// </summary>
-        /// <param name="fullKey">The full configuration key name, like <c>configuration:full:key</c>.</param>
-        /// <returns>
-        /// The last segment in the colon-delimited full key name, like <c>key</c>.
-        /// </returns>
-        private static string GetKeyName(string fullKey)
+        // There are subkeys but not all zero-based sequential numbers - it's a dictionary.
+        var dict = new Dictionary<string, string>();
+        foreach (var subKey in subKeys)
         {
-            int index = fullKey.LastIndexOf(':');
-            if (index < 0)
-            {
-                return fullKey;
-            }
-
-            return fullKey.Substring(index + 1);
+            dict[subKey.Item1] = subKey.Item2;
         }
+
+        return new ConfiguredDictionaryParameter { Dictionary = dict };
+    }
+
+    /// <summary>
+    /// Gets the simple configuration key name from a full, colon-delimited
+    /// configuration key name.
+    /// </summary>
+    /// <param name="fullKey">The full configuration key name, like <c>configuration:full:key</c>.</param>
+    /// <returns>
+    /// The last segment in the colon-delimited full key name, like <c>key</c>.
+    /// </returns>
+    private static string GetKeyName(string fullKey)
+    {
+        int index = fullKey.LastIndexOf(':');
+        if (index < 0)
+        {
+            return fullKey;
+        }
+
+        return fullKey.Substring(index + 1);
     }
 }

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Autofac.Configuration.Util;
 using Autofac.Core;

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -209,9 +209,7 @@ public static class ConfigurationExtensions
             type = defaultAssembly.GetType(typeName, false, true);
         }
 
-        return type == null
-            ? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, typeName))
-            : type;
+        return type ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, typeName));
     }
 
     /// <summary>

--- a/src/Autofac.Configuration/Core/ConfigurationRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationRegistrar.cs
@@ -3,101 +3,100 @@
 
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration.Core
+namespace Autofac.Configuration.Core;
+
+/// <summary>
+/// Default service for adding configured registrations to a container.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This default implementation of <see cref="Autofac.Configuration.IConfigurationRegistrar"/>
+/// processes <see cref="IConfiguration"/> contents into registrations for
+/// a <see cref="Autofac.ContainerBuilder"/>. You may derive and override to extend the functionality
+/// or you may implement your own <see cref="Autofac.Configuration.IConfigurationRegistrar"/>.
+/// </para>
+/// </remarks>
+/// <seealso cref="Autofac.Configuration.IConfigurationRegistrar"/>
+public class ConfigurationRegistrar : IConfigurationRegistrar
 {
     /// <summary>
-    /// Default service for adding configured registrations to a container.
+    /// Initializes a new instance of the <see cref="ConfigurationRegistrar"/> class.
     /// </summary>
+    public ConfigurationRegistrar()
+        : this(new ComponentRegistrar(), new ModuleRegistrar())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationRegistrar"/> class.
+    /// </summary>
+    /// <param name="componentRegistrar">
+    /// The <see cref="IComponentRegistrar"/> that will be used to parse
+    /// configuration values into component registrations.
+    /// </param>
+    /// <param name="moduleRegistrar">
+    /// The <see cref="IModuleRegistrar"/> that will be used to parse
+    /// configuration values into module registrations.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="componentRegistrar" /> or <paramref name="moduleRegistrar" /> is <see langword="null" />.
+    /// </exception>
+    public ConfigurationRegistrar(IComponentRegistrar componentRegistrar, IModuleRegistrar moduleRegistrar)
+    {
+        ComponentRegistrar = componentRegistrar ?? throw new ArgumentNullException(nameof(componentRegistrar));
+        ModuleRegistrar = moduleRegistrar ?? throw new ArgumentNullException(nameof(moduleRegistrar));
+    }
+
+    /// <summary>
+    /// Gets the component registration parser.
+    /// </summary>
+    /// <value>
+    /// The <see cref="IComponentRegistrar"/> that will be used to parse
+    /// configuration values into component registrations.
+    /// </value>
+    public IComponentRegistrar ComponentRegistrar { get; private set; }
+
+    /// <summary>
+    /// Gets the module registration parser.
+    /// </summary>
+    /// <value>
+    /// The <see cref="IModuleRegistrar"/> that will be used to parse
+    /// configuration values into module registrations.
+    /// </value>
+    public IModuleRegistrar ModuleRegistrar { get; private set; }
+
+    /// <summary>
+    /// Registers the contents of a configuration section into a container builder.
+    /// </summary>
+    /// <param name="builder">
+    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// </param>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> containing the configured registrations.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
     /// <remarks>
     /// <para>
-    /// This default implementation of <see cref="Autofac.Configuration.IConfigurationRegistrar"/>
-    /// processes <see cref="IConfiguration"/> contents into registrations for
-    /// a <see cref="Autofac.ContainerBuilder"/>. You may derive and override to extend the functionality
-    /// or you may implement your own <see cref="Autofac.Configuration.IConfigurationRegistrar"/>.
+    /// This method is the primary entry point to configuration section registration. From here,
+    /// the various modules, components, and referenced files get registered. You may override
+    /// any of those behaviors for a custom registrar if you wish to extend registration behavior.
     /// </para>
     /// </remarks>
-    /// <seealso cref="Autofac.Configuration.IConfigurationRegistrar"/>
-    public class ConfigurationRegistrar : IConfigurationRegistrar
+    public virtual void RegisterConfiguration(ContainerBuilder builder, IConfiguration configuration)
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurationRegistrar"/> class.
-        /// </summary>
-        public ConfigurationRegistrar()
-            : this(new ComponentRegistrar(), new ModuleRegistrar())
+        if (builder == null)
         {
+            throw new ArgumentNullException(nameof(builder));
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurationRegistrar"/> class.
-        /// </summary>
-        /// <param name="componentRegistrar">
-        /// The <see cref="IComponentRegistrar"/> that will be used to parse
-        /// configuration values into component registrations.
-        /// </param>
-        /// <param name="moduleRegistrar">
-        /// The <see cref="IModuleRegistrar"/> that will be used to parse
-        /// configuration values into module registrations.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="componentRegistrar" /> or <paramref name="moduleRegistrar" /> is <see langword="null" />.
-        /// </exception>
-        public ConfigurationRegistrar(IComponentRegistrar componentRegistrar, IModuleRegistrar moduleRegistrar)
+        if (configuration == null)
         {
-            ComponentRegistrar = componentRegistrar ?? throw new ArgumentNullException(nameof(componentRegistrar));
-            ModuleRegistrar = moduleRegistrar ?? throw new ArgumentNullException(nameof(moduleRegistrar));
+            throw new ArgumentNullException(nameof(configuration));
         }
 
-        /// <summary>
-        /// Gets the component registration parser.
-        /// </summary>
-        /// <value>
-        /// The <see cref="IComponentRegistrar"/> that will be used to parse
-        /// configuration values into component registrations.
-        /// </value>
-        public IComponentRegistrar ComponentRegistrar { get; private set; }
-
-        /// <summary>
-        /// Gets the module registration parser.
-        /// </summary>
-        /// <value>
-        /// The <see cref="IModuleRegistrar"/> that will be used to parse
-        /// configuration values into module registrations.
-        /// </value>
-        public IModuleRegistrar ModuleRegistrar { get; private set; }
-
-        /// <summary>
-        /// Registers the contents of a configuration section into a container builder.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
-        /// </param>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> containing the configured registrations.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// This method is the primary entry point to configuration section registration. From here,
-        /// the various modules, components, and referenced files get registered. You may override
-        /// any of those behaviors for a custom registrar if you wish to extend registration behavior.
-        /// </para>
-        /// </remarks>
-        public virtual void RegisterConfiguration(ContainerBuilder builder, IConfiguration configuration)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            ModuleRegistrar.RegisterConfiguredModules(builder, configuration);
-            ComponentRegistrar.RegisterConfiguredComponents(builder, configuration);
-        }
+        ModuleRegistrar.RegisterConfiguredModules(builder, configuration);
+        ComponentRegistrar.RegisterConfiguredComponents(builder, configuration);
     }
 }

--- a/src/Autofac.Configuration/Core/ConfigurationRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationRegistrar.cs
@@ -10,13 +10,13 @@ namespace Autofac.Configuration.Core;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This default implementation of <see cref="Autofac.Configuration.IConfigurationRegistrar"/>
+/// This default implementation of <see cref="IConfigurationRegistrar"/>
 /// processes <see cref="IConfiguration"/> contents into registrations for
-/// a <see cref="Autofac.ContainerBuilder"/>. You may derive and override to extend the functionality
-/// or you may implement your own <see cref="Autofac.Configuration.IConfigurationRegistrar"/>.
+/// a <see cref="ContainerBuilder"/>. You may derive and override to extend the functionality
+/// or you may implement your own <see cref="IConfigurationRegistrar"/>.
 /// </para>
 /// </remarks>
-/// <seealso cref="Autofac.Configuration.IConfigurationRegistrar"/>
+/// <seealso cref="IConfigurationRegistrar"/>
 public class ConfigurationRegistrar : IConfigurationRegistrar
 {
     /// <summary>
@@ -38,7 +38,7 @@ public class ConfigurationRegistrar : IConfigurationRegistrar
     /// The <see cref="IModuleRegistrar"/> that will be used to parse
     /// configuration values into module registrations.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="componentRegistrar" /> or <paramref name="moduleRegistrar" /> is <see langword="null" />.
     /// </exception>
     public ConfigurationRegistrar(IComponentRegistrar componentRegistrar, IModuleRegistrar moduleRegistrar)
@@ -69,12 +69,12 @@ public class ConfigurationRegistrar : IConfigurationRegistrar
     /// Registers the contents of a configuration section into a container builder.
     /// </summary>
     /// <param name="builder">
-    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
     /// </param>
     /// <param name="configuration">
     /// The <see cref="IConfiguration"/> containing the configured registrations.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
     /// <remarks>

--- a/src/Autofac.Configuration/Core/ConfigurationRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationRegistrar.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Microsoft.Extensions.Configuration;
 
 namespace Autofac.Configuration.Core

--- a/src/Autofac.Configuration/Core/ModuleRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ModuleRegistrar.cs
@@ -62,7 +62,7 @@ namespace Autofac.Configuration.Core
             }
         }
 
-        private IModule CreateModule(Type type, IConfiguration moduleElement)
+        private static IModule CreateModule(Type type, IConfiguration moduleElement)
         {
             var constructor = GetMostParametersConstructor(type);
 
@@ -72,7 +72,7 @@ namespace Autofac.Configuration.Core
                 .Select(p => parametersElement.GetSection(p.Name).Get(p.ParameterType))
                 .ToArray();
 
-            var module = constructor.Invoke(parameters) as IModule;
+            var module = (IModule)constructor.Invoke(parameters);
 
             var propertiesElement = moduleElement.GetSection("properties");
 

--- a/src/Autofac.Configuration/Core/ModuleRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ModuleRegistrar.cs
@@ -18,15 +18,15 @@ public class ModuleRegistrar : IModuleRegistrar
     /// Registers individual configured modules into a container builder.
     /// </summary>
     /// <param name="builder">
-    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
     /// </param>
     /// <param name="configuration">
     /// The <see cref="IConfiguration"/> containing the configured registrations.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if there is any issue in parsing the module configuration into registrations.
     /// </exception>
     /// <remarks>

--- a/src/Autofac.Configuration/Core/ModuleRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ModuleRegistrar.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;

--- a/src/Autofac.Configuration/Core/ModuleRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ModuleRegistrar.cs
@@ -6,85 +6,84 @@ using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration.Core
+namespace Autofac.Configuration.Core;
+
+/// <summary>
+/// Default module configuration processor.
+/// </summary>
+/// <seealso cref="IModuleRegistrar"/>
+public class ModuleRegistrar : IModuleRegistrar
 {
     /// <summary>
-    /// Default module configuration processor.
+    /// Registers individual configured modules into a container builder.
     /// </summary>
-    /// <seealso cref="IModuleRegistrar"/>
-    public class ModuleRegistrar : IModuleRegistrar
+    /// <param name="builder">
+    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// </param>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> containing the configured registrations.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if there is any issue in parsing the module configuration into registrations.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This is where the individually configured component registrations get added to the <paramref name="builder"/>.
+    /// The <c>modules</c> collection from the <paramref name="configuration"/>
+    /// get processed into individual modules which are instantiated and activated inside the <paramref name="builder"/>.
+    /// </para>
+    /// </remarks>
+    public virtual void RegisterConfiguredModules(ContainerBuilder builder, IConfiguration configuration)
     {
-        /// <summary>
-        /// Registers individual configured modules into a container builder.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
-        /// </param>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> containing the configured registrations.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if there is any issue in parsing the module configuration into registrations.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// This is where the individually configured component registrations get added to the <paramref name="builder"/>.
-        /// The <c>modules</c> collection from the <paramref name="configuration"/>
-        /// get processed into individual modules which are instantiated and activated inside the <paramref name="builder"/>.
-        /// </para>
-        /// </remarks>
-        public virtual void RegisterConfiguredModules(ContainerBuilder builder, IConfiguration configuration)
+        if (builder == null)
         {
-            if (builder == null)
-            {
-                throw new ArgumentNullException(nameof(builder));
-            }
-
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            var defaultAssembly = configuration.DefaultAssembly();
-            foreach (var moduleElement in configuration.GetOrderedSubsections("modules"))
-            {
-                var moduleType = moduleElement.GetType("type", defaultAssembly);
-
-                var module = CreateModule(moduleType, moduleElement);
-
-                builder.RegisterModule(module);
-            }
+            throw new ArgumentNullException(nameof(builder));
         }
 
-        private static IModule CreateModule(Type type, IConfiguration moduleElement)
+        if (configuration == null)
         {
-            var constructor = GetMostParametersConstructor(type);
-
-            var parametersElement = moduleElement.GetSection("parameters");
-
-            var parameters = constructor.GetParameters()
-                .Select(p => parametersElement.GetSection(p.Name).Get(p.ParameterType))
-                .ToArray();
-
-            var module = (IModule)constructor.Invoke(parameters);
-
-            var propertiesElement = moduleElement.GetSection("properties");
-
-            propertiesElement.Bind(module);
-
-            return module;
+            throw new ArgumentNullException(nameof(configuration));
         }
 
-        private static ConstructorInfo GetMostParametersConstructor(Type type)
+        var defaultAssembly = configuration.DefaultAssembly();
+        foreach (var moduleElement in configuration.GetOrderedSubsections("modules"))
         {
-            var finder = new DefaultConstructorFinder();
+            var moduleType = moduleElement.GetType("type", defaultAssembly);
 
-            var publicConstructors = finder.FindConstructors(type);
+            var module = CreateModule(moduleType, moduleElement);
 
-            return publicConstructors.OrderByDescending(x => x.GetParameters().Length).FirstOrDefault();
+            builder.RegisterModule(module);
         }
+    }
+
+    private static IModule CreateModule(Type type, IConfiguration moduleElement)
+    {
+        var constructor = GetMostParametersConstructor(type);
+
+        var parametersElement = moduleElement.GetSection("parameters");
+
+        var parameters = constructor.GetParameters()
+            .Select(p => parametersElement.GetSection(p.Name).Get(p.ParameterType))
+            .ToArray();
+
+        var module = (IModule)constructor.Invoke(parameters);
+
+        var propertiesElement = moduleElement.GetSection("properties");
+
+        propertiesElement.Bind(module);
+
+        return module;
+    }
+
+    private static ConstructorInfo GetMostParametersConstructor(Type type)
+    {
+        var finder = new DefaultConstructorFinder();
+
+        var publicConstructors = finder.FindConstructors(type);
+
+        return publicConstructors.OrderByDescending(x => x.GetParameters().Length).FirstOrDefault();
     }
 }

--- a/src/Autofac.Configuration/IComponentRegistrar.cs
+++ b/src/Autofac.Configuration/IComponentRegistrar.cs
@@ -9,22 +9,22 @@ namespace Autofac.Configuration;
 /// Defines a registration mechanism that converts configuration data
 /// into Autofac component registrations.
 /// </summary>
-/// <seealso cref="Autofac.Configuration.Core.ComponentRegistrar"/>
+/// <seealso cref="Core.ComponentRegistrar"/>
 public interface IComponentRegistrar
 {
     /// <summary>
     /// Registers individual configured components into a container builder.
     /// </summary>
     /// <param name="builder">
-    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
     /// </param>
     /// <param name="configuration">
     /// The <see cref="IConfiguration"/> containing the configured registrations.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if there is any issue in parsing the component configuration into registrations.
     /// </exception>
     /// <remarks>

--- a/src/Autofac.Configuration/IComponentRegistrar.cs
+++ b/src/Autofac.Configuration/IComponentRegistrar.cs
@@ -3,37 +3,36 @@
 
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration
+namespace Autofac.Configuration;
+
+/// <summary>
+/// Defines a registration mechanism that converts configuration data
+/// into Autofac component registrations.
+/// </summary>
+/// <seealso cref="Autofac.Configuration.Core.ComponentRegistrar"/>
+public interface IComponentRegistrar
 {
     /// <summary>
-    /// Defines a registration mechanism that converts configuration data
-    /// into Autofac component registrations.
+    /// Registers individual configured components into a container builder.
     /// </summary>
-    /// <seealso cref="Autofac.Configuration.Core.ComponentRegistrar"/>
-    public interface IComponentRegistrar
-    {
-        /// <summary>
-        /// Registers individual configured components into a container builder.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
-        /// </param>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> containing the configured registrations.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if there is any issue in parsing the component configuration into registrations.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// Implementations of this method are responsible for adding components
-        /// to the container by parsing configuration model data and executing
-        /// the registration logic.
-        /// </para>
-        /// </remarks>
-        void RegisterConfiguredComponents(ContainerBuilder builder, IConfiguration configuration);
-    }
+    /// <param name="builder">
+    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// </param>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> containing the configured registrations.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if there is any issue in parsing the component configuration into registrations.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Implementations of this method are responsible for adding components
+    /// to the container by parsing configuration model data and executing
+    /// the registration logic.
+    /// </para>
+    /// </remarks>
+    void RegisterConfiguredComponents(ContainerBuilder builder, IConfiguration configuration);
 }

--- a/src/Autofac.Configuration/IConfigurationRegistrar.cs
+++ b/src/Autofac.Configuration/IConfigurationRegistrar.cs
@@ -3,22 +3,21 @@
 
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration
+namespace Autofac.Configuration;
+
+/// <summary>
+/// A service for adding configured registrations to a container.
+/// </summary>
+public interface IConfigurationRegistrar
 {
     /// <summary>
-    /// A service for adding configured registrations to a container.
+    /// Registers the contents of a configuration object into a container builder.
     /// </summary>
-    public interface IConfigurationRegistrar
-    {
-        /// <summary>
-        /// Registers the contents of a configuration object into a container builder.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
-        /// </param>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> containing the configured registrations.
-        /// </param>
-        void RegisterConfiguration(ContainerBuilder builder, IConfiguration configuration);
-    }
+    /// <param name="builder">
+    /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
+    /// </param>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> containing the configured registrations.
+    /// </param>
+    void RegisterConfiguration(ContainerBuilder builder, IConfiguration configuration);
 }

--- a/src/Autofac.Configuration/IModuleRegistrar.cs
+++ b/src/Autofac.Configuration/IModuleRegistrar.cs
@@ -9,22 +9,22 @@ namespace Autofac.Configuration;
 /// Defines a registration mechanism that converts configuration data
 /// into Autofac module registrations.
 /// </summary>
-/// <seealso cref="Autofac.Configuration.Core.ModuleRegistrar"/>
+/// <seealso cref="Core.ModuleRegistrar"/>
 public interface IModuleRegistrar
 {
     /// <summary>
     /// Registers individual configured modules into a container builder.
     /// </summary>
     /// <param name="builder">
-    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// The <see cref="ContainerBuilder"/> that should receive the configured registrations.
     /// </param>
     /// <param name="configuration">
     /// The <see cref="IConfiguration"/> containing the configured registrations.
     /// </param>
-    /// <exception cref="System.ArgumentNullException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
     /// </exception>
-    /// <exception cref="System.InvalidOperationException">
+    /// <exception cref="InvalidOperationException">
     /// Thrown if there is any issue in parsing the module configuration into registrations.
     /// </exception>
     /// <remarks>

--- a/src/Autofac.Configuration/IModuleRegistrar.cs
+++ b/src/Autofac.Configuration/IModuleRegistrar.cs
@@ -3,37 +3,36 @@
 
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration
+namespace Autofac.Configuration;
+
+/// <summary>
+/// Defines a registration mechanism that converts configuration data
+/// into Autofac module registrations.
+/// </summary>
+/// <seealso cref="Autofac.Configuration.Core.ModuleRegistrar"/>
+public interface IModuleRegistrar
 {
     /// <summary>
-    /// Defines a registration mechanism that converts configuration data
-    /// into Autofac module registrations.
+    /// Registers individual configured modules into a container builder.
     /// </summary>
-    /// <seealso cref="Autofac.Configuration.Core.ModuleRegistrar"/>
-    public interface IModuleRegistrar
-    {
-        /// <summary>
-        /// Registers individual configured modules into a container builder.
-        /// </summary>
-        /// <param name="builder">
-        /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
-        /// </param>
-        /// <param name="configuration">
-        /// The <see cref="IConfiguration"/> containing the configured registrations.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="System.InvalidOperationException">
-        /// Thrown if there is any issue in parsing the module configuration into registrations.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// Implementations of this method are responsible for adding modules
-        /// to the container by parsing configuration model data and executing
-        /// the registration logic.
-        /// </para>
-        /// </remarks>
-        void RegisterConfiguredModules(ContainerBuilder builder, IConfiguration configuration);
-    }
+    /// <param name="builder">
+    /// The <see cref="Autofac.ContainerBuilder"/> that should receive the configured registrations.
+    /// </param>
+    /// <param name="configuration">
+    /// The <see cref="IConfiguration"/> containing the configured registrations.
+    /// </param>
+    /// <exception cref="System.ArgumentNullException">
+    /// Thrown if <paramref name="builder"/> or <paramref name="configuration"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="System.InvalidOperationException">
+    /// Thrown if there is any issue in parsing the module configuration into registrations.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Implementations of this method are responsible for adding modules
+    /// to the container by parsing configuration model data and executing
+    /// the registration logic.
+    /// </para>
+    /// </remarks>
+    void RegisterConfiguredModules(ContainerBuilder builder, IConfiguration configuration);
 }

--- a/src/Autofac.Configuration/NullableAttributes.cs
+++ b/src/Autofac.Configuration/NullableAttributes.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma warning disable MA0048 // File name must match type name
+#pragma warning disable SA1402 // File may only contain a single type
+#pragma warning disable SA1649 // File name should match first type name
+#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+internal sealed class AllowNullAttribute : Attribute
+{
+}
+
+/// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+internal sealed class DisallowNullAttribute : Attribute
+{
+}
+
+/// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+internal sealed class MaybeNullAttribute : Attribute
+{
+}
+
+/// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+internal sealed class NotNullAttribute : Attribute
+{
+}
+
+/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class MaybeNullWhenAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MaybeNullWhenAttribute"/> class with the specified return value condition.
+    /// </summary>
+    /// <param name="returnValue">
+    /// The return value condition. If the method returns this value, the associated parameter may be null.
+    /// </param>
+    public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the return value is required to be true or false.
+    /// </summary>
+    public bool ReturnValue { get; }
+}
+
+/// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class NotNullWhenAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotNullWhenAttribute"/> class with the specified return value condition.</summary>
+    /// <param name="returnValue">
+    /// The return value condition. If the method returns this value, the associated parameter will not be null.
+    /// </param>
+    public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the return value is required to be true or false.
+    /// </summary>
+    public bool ReturnValue { get; }
+}
+
+/// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+internal sealed class NotNullIfNotNullAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotNullIfNotNullAttribute"/> class with the associated parameter name.</summary>
+    /// <param name="parameterName">
+    /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+    /// </param>
+    public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+    /// <summary>
+    /// Gets the name of the parameter.
+    /// </summary>
+    public string ParameterName { get; }
+}
+
+/// <summary>Applied to a method that will never return under any circumstance.</summary>
+[AttributeUsage(AttributeTargets.Method, Inherited = false)]
+internal sealed class DoesNotReturnAttribute : Attribute
+{
+}
+
+/// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+[AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+internal sealed class DoesNotReturnIfAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DoesNotReturnIfAttribute"/> class with the specified parameter value.</summary>
+    /// <param name="parameterValue">
+    /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+    /// the associated parameter matches this value.
+    /// </param>
+    public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+    /// <summary>
+    /// Gets a value indicating whether the parameter value is expected to be true or false.
+    /// </summary>
+    public bool ParameterValue { get; }
+}
+#endif

--- a/src/Autofac.Configuration/Properties/AssemblyInfo.cs
+++ b/src/Autofac.Configuration/Properties/AssemblyInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
@@ -5,82 +5,81 @@ using System.Collections;
 using System.ComponentModel;
 using System.Globalization;
 
-namespace Autofac.Configuration.Util
+namespace Autofac.Configuration.Util;
+
+/// <summary>
+/// Configuration settings that provide a dictionary parameter to a registration.
+/// </summary>
+[TypeConverter(typeof(DictionaryTypeConverter))]
+internal class ConfiguredDictionaryParameter
 {
     /// <summary>
-    /// Configuration settings that provide a dictionary parameter to a registration.
+    /// Gets or sets the dictionary of raw values.
     /// </summary>
-    [TypeConverter(typeof(DictionaryTypeConverter))]
-    internal class ConfiguredDictionaryParameter
+    public Dictionary<string, string>? Dictionary { get; set; }
+
+    private class DictionaryTypeConverter : TypeConverter
     {
-        /// <summary>
-        /// Gets or sets the dictionary of raw values.
-        /// </summary>
-        public Dictionary<string, string>? Dictionary { get; set; }
-
-        private class DictionaryTypeConverter : TypeConverter
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+            var instantiableType = GetInstantiableType(destinationType);
+
+            if (value is ConfiguredDictionaryParameter castValue && instantiableType != null)
             {
-                var instantiableType = GetInstantiableType(destinationType);
+                var dictionary = (IDictionary)Activator.CreateInstance(instantiableType);
+                var generics = instantiableType.GetGenericArguments();
 
-                if (value is ConfiguredDictionaryParameter castValue && instantiableType != null)
+                if (castValue.Dictionary != null)
                 {
-                    var dictionary = (IDictionary)Activator.CreateInstance(instantiableType);
-                    var generics = instantiableType.GetGenericArguments();
-
-                    if (castValue.Dictionary != null)
+                    foreach (var item in castValue.Dictionary)
                     {
-                        foreach (var item in castValue.Dictionary)
+                        if (string.IsNullOrEmpty(item.Key))
                         {
-                            if (string.IsNullOrEmpty(item.Key))
-                            {
-                                throw new FormatException(ConfigurationResources.DictionaryKeyMayNotBeNullOrEmpty);
-                            }
-
-                            var convertedKey = TypeManipulation.ChangeToCompatibleType(item.Key, generics[0]);
-                            var convertedValue = TypeManipulation.ChangeToCompatibleType(item.Value, generics[1]);
-
-                            dictionary.Add(convertedKey, convertedValue);
+                            throw new FormatException(ConfigurationResources.DictionaryKeyMayNotBeNullOrEmpty);
                         }
-                    }
 
-                    return dictionary;
+                        var convertedKey = TypeManipulation.ChangeToCompatibleType(item.Key, generics[0]);
+                        var convertedValue = TypeManipulation.ChangeToCompatibleType(item.Value, generics[1]);
+
+                        dictionary.Add(convertedKey, convertedValue);
+                    }
                 }
 
-                return base.ConvertTo(context, culture, value, destinationType);
+                return dictionary;
             }
 
-            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (GetInstantiableType(destinationType) != null)
             {
-                if (GetInstantiableType(destinationType) != null)
-                {
-                    return true;
-                }
-
-                return base.CanConvertTo(context, destinationType);
+                return true;
             }
 
-            private static Type? GetInstantiableType(Type destinationType)
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        private static Type? GetInstantiableType(Type destinationType)
+        {
+            if (typeof(IDictionary).IsAssignableFrom(destinationType) ||
+                (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition())))
             {
-                if (typeof(IDictionary).IsAssignableFrom(destinationType) ||
-                    (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition())))
+                var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(string), typeof(object) };
+                if (generics.Length != 2)
                 {
-                    var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(string), typeof(object) };
-                    if (generics.Length != 2)
-                    {
-                        return null;
-                    }
-
-                    var dictType = typeof(Dictionary<,>).MakeGenericType(generics);
-                    if (destinationType.IsAssignableFrom(dictType))
-                    {
-                        return dictType;
-                    }
+                    return null;
                 }
 
-                return null;
+                var dictType = typeof(Dictionary<,>).MakeGenericType(generics);
+                if (destinationType.IsAssignableFrom(dictType))
+                {
+                    return dictType;
+                }
             }
+
+            return null;
         }
     }
 }

--- a/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
@@ -53,7 +53,7 @@ internal class ConfiguredDictionaryParameter
 
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            return GetInstantiableType(destinationType) != null ? true : base.CanConvertTo(context, destinationType);
+            return GetInstantiableType(destinationType) != null || base.CanConvertTo(context, destinationType);
         }
 
         private static Type? GetInstantiableType(Type destinationType)

--- a/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
@@ -53,12 +53,7 @@ internal class ConfiguredDictionaryParameter
 
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (GetInstantiableType(destinationType) != null)
-            {
-                return true;
-            }
-
-            return base.CanConvertTo(context, destinationType);
+            return GetInstantiableType(destinationType) != null ? true : base.CanConvertTo(context, destinationType);
         }
 
         private static Type? GetInstantiableType(Type destinationType)

--- a/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -21,9 +21,9 @@ internal class ConfiguredListParameter
     {
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            return GetInstantiableListType(destinationType) != null || GetInstantiableDictionaryType(destinationType) != null
-                ? true
-                : base.CanConvertTo(context, destinationType);
+            return GetInstantiableListType(destinationType) != null ||
+                    GetInstantiableDictionaryType(destinationType) != null ||
+                    base.CanConvertTo(context, destinationType);
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -4,141 +4,140 @@
 using System.Collections;
 using System.ComponentModel;
 
-namespace Autofac.Configuration.Util
+namespace Autofac.Configuration.Util;
+
+/// <summary>
+/// Configuration settings that provide a list parameter to a registration.
+/// </summary>
+[TypeConverter(typeof(ListTypeConverter))]
+internal class ConfiguredListParameter
 {
     /// <summary>
-    /// Configuration settings that provide a list parameter to a registration.
+    /// Gets or sets the list of raw values.
     /// </summary>
-    [TypeConverter(typeof(ListTypeConverter))]
-    internal class ConfiguredListParameter
+    public string[]? List { get; set; }
+
+    private class ListTypeConverter : TypeConverter
     {
-        /// <summary>
-        /// Gets or sets the list of raw values.
-        /// </summary>
-        public string[]? List { get; set; }
-
-        private class ListTypeConverter : TypeConverter
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+            if (GetInstantiableListType(destinationType) != null || GetInstantiableDictionaryType(destinationType) != null)
             {
-                if (GetInstantiableListType(destinationType) != null || GetInstantiableDictionaryType(destinationType) != null)
-                {
-                    return true;
-                }
-
-                return base.CanConvertTo(context, destinationType);
+                return true;
             }
 
-            public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is ConfiguredListParameter castValue)
             {
-                if (value is ConfiguredListParameter castValue)
+                // 99% of the time this type of parameter will be associated
+                // with an ordinal list - List<T> or T[] sort of thing...
+                var instantiableType = GetInstantiableListType(destinationType);
+                if (instantiableType != null)
                 {
-                    // 99% of the time this type of parameter will be associated
-                    // with an ordinal list - List<T> or T[] sort of thing...
-                    var instantiableType = GetInstantiableListType(destinationType);
-                    if (instantiableType != null)
+                    var collection = (IList)Activator.CreateInstance(instantiableType);
+                    if (castValue.List != null)
                     {
-                        var collection = (IList)Activator.CreateInstance(instantiableType);
-                        if (castValue.List != null)
+                        var generics = instantiableType.GetGenericArguments();
+                        foreach (string item in castValue.List)
                         {
-                            var generics = instantiableType.GetGenericArguments();
-                            foreach (string item in castValue.List)
-                            {
-                                collection.Add(TypeManipulation.ChangeToCompatibleType(item, generics[0]));
-                            }
+                            collection.Add(TypeManipulation.ChangeToCompatibleType(item, generics[0]));
                         }
-
-                        return collection;
                     }
 
-                    // ...but there is a very small chance this is a Dictionary<int, T> where
-                    // the keys are all 0-based and ordinal. This clause checks for
-                    // that one edge case. We should only have gotten here if
-                    // ConfigurationExtensions.GetConfiguredParameterValue saw
-                    // a 0-based configuration dictionary.
-                    instantiableType = GetInstantiableDictionaryType(destinationType);
-                    if (instantiableType != null)
+                    return collection;
+                }
+
+                // ...but there is a very small chance this is a Dictionary<int, T> where
+                // the keys are all 0-based and ordinal. This clause checks for
+                // that one edge case. We should only have gotten here if
+                // ConfigurationExtensions.GetConfiguredParameterValue saw
+                // a 0-based configuration dictionary.
+                instantiableType = GetInstantiableDictionaryType(destinationType);
+                if (instantiableType != null)
+                {
+                    var dictionary = (IDictionary)Activator.CreateInstance(instantiableType);
+                    if (castValue.List != null)
                     {
-                        var dictionary = (IDictionary)Activator.CreateInstance(instantiableType);
-                        if (castValue.List != null)
+                        var generics = instantiableType.GetGenericArguments();
+                        for (int i = 0; i < castValue.List.Length; i++)
                         {
-                            var generics = instantiableType.GetGenericArguments();
-                            for (int i = 0; i < castValue.List.Length; i++)
-                            {
-                                var convertedKey = TypeManipulation.ChangeToCompatibleType(i, generics[0]);
-                                var convertedValue = TypeManipulation.ChangeToCompatibleType(castValue.List[i], generics[1]);
+                            var convertedKey = TypeManipulation.ChangeToCompatibleType(i, generics[0]);
+                            var convertedValue = TypeManipulation.ChangeToCompatibleType(castValue.List[i], generics[1]);
 
-                                dictionary.Add(convertedKey, convertedValue);
-                            }
+                            dictionary.Add(convertedKey, convertedValue);
                         }
-
-                        return dictionary;
                     }
-                }
 
-                return base.ConvertTo(context, culture, value, destinationType);
+                    return dictionary;
+                }
             }
 
-            /// <summary>
-            /// Handles type determination for the case where the dictionary
-            /// has numeric/ordinal keys.
-            /// </summary>
-            /// <param name="destinationType">
-            /// The type to which the list content should be converted.
-            /// </param>
-            /// <returns>
-            /// A dictionary type where the key can be numeric.
-            /// </returns>
-            private static Type? GetInstantiableDictionaryType(Type destinationType)
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        /// <summary>
+        /// Handles type determination for the case where the dictionary
+        /// has numeric/ordinal keys.
+        /// </summary>
+        /// <param name="destinationType">
+        /// The type to which the list content should be converted.
+        /// </param>
+        /// <returns>
+        /// A dictionary type where the key can be numeric.
+        /// </returns>
+        private static Type? GetInstantiableDictionaryType(Type destinationType)
+        {
+            if (typeof(IDictionary).IsAssignableFrom(destinationType) ||
+                (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition())))
             {
-                if (typeof(IDictionary).IsAssignableFrom(destinationType) ||
-                    (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition())))
+                var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(int), typeof(object) };
+                if (generics.Length != 2)
                 {
-                    var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(int), typeof(object) };
-                    if (generics.Length != 2)
-                    {
-                        return null;
-                    }
-
-                    var dictType = typeof(Dictionary<,>).MakeGenericType(generics);
-                    if (destinationType.IsAssignableFrom(dictType))
-                    {
-                        return dictType;
-                    }
+                    return null;
                 }
 
-                return null;
+                var dictType = typeof(Dictionary<,>).MakeGenericType(generics);
+                if (destinationType.IsAssignableFrom(dictType))
+                {
+                    return dictType;
+                }
             }
 
-            /// <summary>
-            /// Handles type determination list conversion.
-            /// </summary>
-            /// <param name="destinationType">
-            /// The type to which the list content should be converted.
-            /// </param>
-            /// <returns>
-            /// A list type compatible with the data values.
-            /// </returns>
-            private static Type? GetInstantiableListType(Type destinationType)
+            return null;
+        }
+
+        /// <summary>
+        /// Handles type determination list conversion.
+        /// </summary>
+        /// <param name="destinationType">
+        /// The type to which the list content should be converted.
+        /// </param>
+        /// <returns>
+        /// A list type compatible with the data values.
+        /// </returns>
+        private static Type? GetInstantiableListType(Type destinationType)
+        {
+            if (typeof(IEnumerable).IsAssignableFrom(destinationType))
             {
-                if (typeof(IEnumerable).IsAssignableFrom(destinationType))
+                var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(object) };
+                if (generics.Length != 1)
                 {
-                    var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(object) };
-                    if (generics.Length != 1)
-                    {
-                        return null;
-                    }
-
-                    var listType = typeof(List<>).MakeGenericType(generics);
-
-                    if (destinationType.IsAssignableFrom(listType))
-                    {
-                        return listType;
-                    }
+                    return null;
                 }
 
-                return null;
+                var listType = typeof(List<>).MakeGenericType(generics);
+
+                if (destinationType.IsAssignableFrom(listType))
+                {
+                    return listType;
+                }
             }
+
+            return null;
         }
     }
 }

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -21,12 +21,9 @@ internal class ConfiguredListParameter
     {
         public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
         {
-            if (GetInstantiableListType(destinationType) != null || GetInstantiableDictionaryType(destinationType) != null)
-            {
-                return true;
-            }
-
-            return base.CanConvertTo(context, destinationType);
+            return GetInstantiableListType(destinationType) != null || GetInstantiableDictionaryType(destinationType) != null
+                ? true
+                : base.CanConvertTo(context, destinationType);
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Reflection;
 
 namespace Autofac.Configuration.Util
 {

--- a/src/Autofac.Configuration/Util/ReflectionExtensions.cs
+++ b/src/Autofac.Configuration/Util/ReflectionExtensions.cs
@@ -16,7 +16,7 @@ namespace Autofac.Configuration.Util
         /// <param name="pi">Parameter to the property setter.</param>
         /// <param name="prop">The property info on which the setter is specified.</param>
         /// <returns>True if the parameter is a property setter.</returns>
-        public static bool TryGetDeclaringProperty(this ParameterInfo pi, out PropertyInfo prop)
+        public static bool TryGetDeclaringProperty(this ParameterInfo pi, [NotNullWhen(true)] out PropertyInfo? prop)
         {
             var mi = pi.Member as MethodInfo;
             if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", System.StringComparison.Ordinal))

--- a/src/Autofac.Configuration/Util/ReflectionExtensions.cs
+++ b/src/Autofac.Configuration/Util/ReflectionExtensions.cs
@@ -3,30 +3,29 @@
 
 using System.Reflection;
 
-namespace Autofac.Configuration.Util
+namespace Autofac.Configuration.Util;
+
+/// <summary>
+/// Extension methods for reflection-related types.
+/// </summary>
+internal static class ReflectionExtensions
 {
     /// <summary>
-    /// Extension methods for reflection-related types.
+    /// Maps from a property-set-value parameter to the declaring property.
     /// </summary>
-    internal static class ReflectionExtensions
+    /// <param name="pi">Parameter to the property setter.</param>
+    /// <param name="prop">The property info on which the setter is specified.</param>
+    /// <returns>True if the parameter is a property setter.</returns>
+    public static bool TryGetDeclaringProperty(this ParameterInfo pi, [NotNullWhen(true)] out PropertyInfo? prop)
     {
-        /// <summary>
-        /// Maps from a property-set-value parameter to the declaring property.
-        /// </summary>
-        /// <param name="pi">Parameter to the property setter.</param>
-        /// <param name="prop">The property info on which the setter is specified.</param>
-        /// <returns>True if the parameter is a property setter.</returns>
-        public static bool TryGetDeclaringProperty(this ParameterInfo pi, [NotNullWhen(true)] out PropertyInfo? prop)
+        var mi = pi.Member as MethodInfo;
+        if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", System.StringComparison.Ordinal))
         {
-            var mi = pi.Member as MethodInfo;
-            if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", System.StringComparison.Ordinal))
-            {
-                prop = mi.DeclaringType.GetProperty(mi.Name.Substring(4));
-                return true;
-            }
-
-            prop = null;
-            return false;
+            prop = mi.DeclaringType.GetProperty(mi.Name.Substring(4));
+            return true;
         }
+
+        prop = null;
+        return false;
     }
 }

--- a/src/Autofac.Configuration/Util/ReflectionExtensions.cs
+++ b/src/Autofac.Configuration/Util/ReflectionExtensions.cs
@@ -19,7 +19,7 @@ internal static class ReflectionExtensions
     public static bool TryGetDeclaringProperty(this ParameterInfo pi, [NotNullWhen(true)] out PropertyInfo? prop)
     {
         var mi = pi.Member as MethodInfo;
-        if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", System.StringComparison.Ordinal))
+        if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", StringComparison.Ordinal))
         {
             prop = mi.DeclaringType.GetProperty(mi.Name.Substring(4));
             return true;

--- a/src/Autofac.Configuration/Util/StringExtensions.cs
+++ b/src/Autofac.Configuration/Util/StringExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Globalization;
 
 namespace Autofac.Configuration.Util

--- a/src/Autofac.Configuration/Util/StringExtensions.cs
+++ b/src/Autofac.Configuration/Util/StringExtensions.cs
@@ -3,46 +3,45 @@
 
 using System.Globalization;
 
-namespace Autofac.Configuration.Util
+namespace Autofac.Configuration.Util;
+
+/// <summary>
+/// Extension methods for parsing string values from configuration.
+/// </summary>
+public static class StringExtensions
 {
     /// <summary>
-    /// Extension methods for parsing string values from configuration.
+    /// Uses a flexible parsing routine to convert a text value into
+    /// a <see cref="bool"/>.
     /// </summary>
-    public static class StringExtensions
+    /// <param name="value">
+    /// The value to parse into a <see cref="bool"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> or <see langword="false" /> based on the
+    /// content of the <paramref name="value" />.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <paramref name="value" /> can't be parsed into a <see cref="bool"/>.
+    /// </exception>
+    public static bool ToFlexibleBoolean(this string value)
     {
-        /// <summary>
-        /// Uses a flexible parsing routine to convert a text value into
-        /// a <see cref="bool"/>.
-        /// </summary>
-        /// <param name="value">
-        /// The value to parse into a <see cref="bool"/>.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> or <see langword="false" /> based on the
-        /// content of the <paramref name="value" />.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if <paramref name="value" /> can't be parsed into a <see cref="bool"/>.
-        /// </exception>
-        public static bool ToFlexibleBoolean(this string value)
+        if (string.IsNullOrWhiteSpace(value) ||
+            value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("n", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("0", StringComparison.OrdinalIgnoreCase))
         {
-            if (string.IsNullOrWhiteSpace(value) ||
-                value.Equals("false", StringComparison.OrdinalIgnoreCase) ||
-                value.Equals("no", StringComparison.OrdinalIgnoreCase) ||
-                value.Equals("n", StringComparison.OrdinalIgnoreCase) ||
-                value.Equals("0", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-            else if (value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-                value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
-                value.Equals("y", StringComparison.OrdinalIgnoreCase) ||
-                value.Equals("1", StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.UnrecognisedBoolean, value));
+            return false;
         }
+        else if (value.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("y", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("1", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.UnrecognisedBoolean, value));
     }
 }

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -29,9 +29,9 @@ namespace Autofac.Configuration.Util
         /// <exception cref="InvalidOperationException">
         /// Thrown if conversion of the value fails.
         /// </exception>
-        public static object ChangeToCompatibleType(object value, Type destinationType, ParameterInfo memberInfo)
+        public static object? ChangeToCompatibleType(object value, Type destinationType, ParameterInfo memberInfo)
         {
-            var attrib = (TypeConverterAttribute)null;
+            TypeConverterAttribute? attrib = null;
             if (memberInfo != null)
             {
                 attrib = memberInfo.GetCustomAttributes(typeof(TypeConverterAttribute), true).Cast<TypeConverterAttribute>().FirstOrDefault();
@@ -55,9 +55,9 @@ namespace Autofac.Configuration.Util
         /// <exception cref="InvalidOperationException">
         /// Thrown if conversion of the value fails.
         /// </exception>
-        public static object ChangeToCompatibleType(object value, Type destinationType, MemberInfo memberInfo)
+        public static object? ChangeToCompatibleType(object value, Type destinationType, MemberInfo memberInfo)
         {
-            var attrib = (TypeConverterAttribute)null;
+            TypeConverterAttribute? attrib = null;
             if (memberInfo != null)
             {
                 attrib = memberInfo.GetCustomAttributes(typeof(TypeConverterAttribute), true).Cast<TypeConverterAttribute>().FirstOrDefault();
@@ -81,7 +81,7 @@ namespace Autofac.Configuration.Util
         /// <exception cref="InvalidOperationException">
         /// Thrown if conversion of the value fails.
         /// </exception>
-        public static object ChangeToCompatibleType(object value, Type destinationType, TypeConverterAttribute converterAttribute = null)
+        public static object? ChangeToCompatibleType(object value, Type destinationType, TypeConverterAttribute? converterAttribute = null)
         {
             if (destinationType == null)
             {

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -158,7 +158,7 @@ internal class TypeManipulation
     private static TypeConverter GetTypeConverterFromName(string converterTypeName)
     {
         var converterType = Type.GetType(converterTypeName, true);
-        return !(Activator.CreateInstance(converterType) is TypeConverter converter)
+        return Activator.CreateInstance(converterType) is not TypeConverter converter
             ? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConverterAttributeTypeNotConverter, converterTypeName))
             : converter;
     }

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -158,11 +158,8 @@ internal class TypeManipulation
     private static TypeConverter GetTypeConverterFromName(string converterTypeName)
     {
         var converterType = Type.GetType(converterTypeName, true);
-        if (!(Activator.CreateInstance(converterType) is TypeConverter converter))
-        {
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConverterAttributeTypeNotConverter, converterTypeName));
-        }
-
-        return converter;
+        return !(Activator.CreateInstance(converterType) is TypeConverter converter)
+            ? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConverterAttributeTypeNotConverter, converterTypeName))
+            : converter;
     }
 }

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -5,165 +5,164 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
 
-namespace Autofac.Configuration.Util
+namespace Autofac.Configuration.Util;
+
+/// <summary>
+/// Utilities for converting string configuration values into strongly-typed objects.
+/// </summary>
+internal class TypeManipulation
 {
     /// <summary>
-    /// Utilities for converting string configuration values into strongly-typed objects.
+    /// Converts an object to a type compatible with a given parameter.
     /// </summary>
-    internal class TypeManipulation
+    /// <param name="value">The object value to convert.</param>
+    /// <param name="destinationType">The destination <see cref="Type"/> to which <paramref name="value"/> should be converted.</param>
+    /// <param name="memberInfo">The parameter for which the <paramref name="value"/> is being converted.</param>
+    /// <returns>
+    /// An <see cref="object"/> of type <paramref name="destinationType"/>, converted using
+    /// type converters specified on <paramref name="memberInfo"/> if available. If <paramref name="value"/>
+    /// is <see langword="null"/> then the output will be <see langword="null"/> for reference
+    /// types and the default value for value types.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if conversion of the value fails.
+    /// </exception>
+    public static object? ChangeToCompatibleType(object value, Type destinationType, ParameterInfo memberInfo)
     {
-        /// <summary>
-        /// Converts an object to a type compatible with a given parameter.
-        /// </summary>
-        /// <param name="value">The object value to convert.</param>
-        /// <param name="destinationType">The destination <see cref="Type"/> to which <paramref name="value"/> should be converted.</param>
-        /// <param name="memberInfo">The parameter for which the <paramref name="value"/> is being converted.</param>
-        /// <returns>
-        /// An <see cref="object"/> of type <paramref name="destinationType"/>, converted using
-        /// type converters specified on <paramref name="memberInfo"/> if available. If <paramref name="value"/>
-        /// is <see langword="null"/> then the output will be <see langword="null"/> for reference
-        /// types and the default value for value types.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if conversion of the value fails.
-        /// </exception>
-        public static object? ChangeToCompatibleType(object value, Type destinationType, ParameterInfo memberInfo)
+        TypeConverterAttribute? attrib = null;
+        if (memberInfo != null)
         {
-            TypeConverterAttribute? attrib = null;
-            if (memberInfo != null)
-            {
-                attrib = memberInfo.GetCustomAttributes(typeof(TypeConverterAttribute), true).Cast<TypeConverterAttribute>().FirstOrDefault();
-            }
-
-            return ChangeToCompatibleType(value, destinationType, attrib);
+            attrib = memberInfo.GetCustomAttributes(typeof(TypeConverterAttribute), true).Cast<TypeConverterAttribute>().FirstOrDefault();
         }
 
-        /// <summary>
-        /// Converts an object to a type compatible with a given parameter.
-        /// </summary>
-        /// <param name="value">The object value to convert.</param>
-        /// <param name="destinationType">The destination <see cref="Type"/> to which <paramref name="value"/> should be converted.</param>
-        /// <param name="memberInfo">The parameter for which the <paramref name="value"/> is being converted.</param>
-        /// <returns>
-        /// An <see cref="object"/> of type <paramref name="destinationType"/>, converted using
-        /// type converters specified on <paramref name="memberInfo"/> if available. If <paramref name="value"/>
-        /// is <see langword="null"/> then the output will be <see langword="null"/> for reference
-        /// types and the default value for value types.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if conversion of the value fails.
-        /// </exception>
-        public static object? ChangeToCompatibleType(object value, Type destinationType, MemberInfo memberInfo)
-        {
-            TypeConverterAttribute? attrib = null;
-            if (memberInfo != null)
-            {
-                attrib = memberInfo.GetCustomAttributes(typeof(TypeConverterAttribute), true).Cast<TypeConverterAttribute>().FirstOrDefault();
-            }
+        return ChangeToCompatibleType(value, destinationType, attrib);
+    }
 
-            return ChangeToCompatibleType(value, destinationType, attrib);
+    /// <summary>
+    /// Converts an object to a type compatible with a given parameter.
+    /// </summary>
+    /// <param name="value">The object value to convert.</param>
+    /// <param name="destinationType">The destination <see cref="Type"/> to which <paramref name="value"/> should be converted.</param>
+    /// <param name="memberInfo">The parameter for which the <paramref name="value"/> is being converted.</param>
+    /// <returns>
+    /// An <see cref="object"/> of type <paramref name="destinationType"/>, converted using
+    /// type converters specified on <paramref name="memberInfo"/> if available. If <paramref name="value"/>
+    /// is <see langword="null"/> then the output will be <see langword="null"/> for reference
+    /// types and the default value for value types.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if conversion of the value fails.
+    /// </exception>
+    public static object? ChangeToCompatibleType(object value, Type destinationType, MemberInfo memberInfo)
+    {
+        TypeConverterAttribute? attrib = null;
+        if (memberInfo != null)
+        {
+            attrib = memberInfo.GetCustomAttributes(typeof(TypeConverterAttribute), true).Cast<TypeConverterAttribute>().FirstOrDefault();
         }
 
-        /// <summary>
-        /// Converts an object to a type compatible with a given parameter.
-        /// </summary>
-        /// <param name="value">The object value to convert.</param>
-        /// <param name="destinationType">The destination <see cref="Type"/> to which <paramref name="value"/> should be converted.</param>
-        /// <param name="converterAttribute">A <see cref="TypeConverterAttribute"/>, if available, specifying the type of converter to use.<paramref name="value"/> is being converted.</param>
-        /// <returns>
-        /// An <see cref="object"/> of type <paramref name="destinationType"/>, converted using
-        /// any type converters specified in <paramref name="converterAttribute"/> if available. If <paramref name="value"/>
-        /// is <see langword="null"/> then the output will be <see langword="null"/> for reference
-        /// types and the default value for value types.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if conversion of the value fails.
-        /// </exception>
-        public static object? ChangeToCompatibleType(object value, Type destinationType, TypeConverterAttribute? converterAttribute = null)
+        return ChangeToCompatibleType(value, destinationType, attrib);
+    }
+
+    /// <summary>
+    /// Converts an object to a type compatible with a given parameter.
+    /// </summary>
+    /// <param name="value">The object value to convert.</param>
+    /// <param name="destinationType">The destination <see cref="Type"/> to which <paramref name="value"/> should be converted.</param>
+    /// <param name="converterAttribute">A <see cref="TypeConverterAttribute"/>, if available, specifying the type of converter to use.<paramref name="value"/> is being converted.</param>
+    /// <returns>
+    /// An <see cref="object"/> of type <paramref name="destinationType"/>, converted using
+    /// any type converters specified in <paramref name="converterAttribute"/> if available. If <paramref name="value"/>
+    /// is <see langword="null"/> then the output will be <see langword="null"/> for reference
+    /// types and the default value for value types.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if conversion of the value fails.
+    /// </exception>
+    public static object? ChangeToCompatibleType(object value, Type destinationType, TypeConverterAttribute? converterAttribute = null)
+    {
+        if (destinationType == null)
         {
-            if (destinationType == null)
-            {
-                throw new ArgumentNullException(nameof(destinationType));
-            }
+            throw new ArgumentNullException(nameof(destinationType));
+        }
 
-            if (value == null)
-            {
-                return destinationType.GetTypeInfo().IsValueType ? Activator.CreateInstance(destinationType) : null;
-            }
+        if (value == null)
+        {
+            return destinationType.GetTypeInfo().IsValueType ? Activator.CreateInstance(destinationType) : null;
+        }
 
-            // Try implicit conversion.
-            if (destinationType.IsInstanceOfType(value))
-            {
-                return value;
-            }
+        // Try implicit conversion.
+        if (destinationType.IsInstanceOfType(value))
+        {
+            return value;
+        }
 
-            TypeConverter converter;
+        TypeConverter converter;
 
-            // Try to get custom type converter information.
-            if (converterAttribute != null && !string.IsNullOrEmpty(converterAttribute.ConverterTypeName))
-            {
-                converter = GetTypeConverterFromName(converterAttribute.ConverterTypeName);
-                if (converter.CanConvertFrom(value.GetType()))
-                {
-                    return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
-                }
-            }
-
-            // If there's not a custom converter specified via attribute, try for a default.
-            converter = TypeDescriptor.GetConverter(value.GetType());
-            if (converter.CanConvertTo(destinationType))
-            {
-                return converter.ConvertTo(null, CultureInfo.InvariantCulture, value, destinationType);
-            }
-
-            // Try explicit opposite conversion.
-            converter = TypeDescriptor.GetConverter(destinationType);
+        // Try to get custom type converter information.
+        if (converterAttribute != null && !string.IsNullOrEmpty(converterAttribute.ConverterTypeName))
+        {
+            converter = GetTypeConverterFromName(converterAttribute.ConverterTypeName);
             if (converter.CanConvertFrom(value.GetType()))
             {
                 return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
             }
+        }
 
-            // Try a TryParse method.
-            if (value is string)
+        // If there's not a custom converter specified via attribute, try for a default.
+        converter = TypeDescriptor.GetConverter(value.GetType());
+        if (converter.CanConvertTo(destinationType))
+        {
+            return converter.ConvertTo(null, CultureInfo.InvariantCulture, value, destinationType);
+        }
+
+        // Try explicit opposite conversion.
+        converter = TypeDescriptor.GetConverter(destinationType);
+        if (converter.CanConvertFrom(value.GetType()))
+        {
+            return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+        }
+
+        // Try a TryParse method.
+        if (value is string)
+        {
+            // Some types in later frameworks have string TryParse and ReadOnlySpan<char> TryParse
+            // so they result in an AmbiguousMatchException unless we specify.
+            var parser = destinationType.GetMethod("TryParse", BindingFlags.Static | BindingFlags.Public, null, CallingConventions.Standard, new Type[] { typeof(string), destinationType.MakeByRefType() }, null);
+            if (parser != null)
             {
-                // Some types in later frameworks have string TryParse and ReadOnlySpan<char> TryParse
-                // so they result in an AmbiguousMatchException unless we specify.
-                var parser = destinationType.GetMethod("TryParse", BindingFlags.Static | BindingFlags.Public, null, CallingConventions.Standard, new Type[] { typeof(string), destinationType.MakeByRefType() }, null);
-                if (parser != null)
+                var parameters = new[] { value, null };
+                if ((bool)parser.Invoke(null, parameters))
                 {
-                    var parameters = new[] { value, null };
-                    if ((bool)parser.Invoke(null, parameters))
-                    {
-                        return parameters[1];
-                    }
+                    return parameters[1];
                 }
             }
-
-            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConversionUnsupported, value.GetType(), destinationType));
         }
 
-        /// <summary>
-        /// Instantiates a type converter from its type name.
-        /// </summary>
-        /// <param name="converterTypeName">
-        /// The name of the <see cref="Type"/> of the <see cref="TypeConverter"/>.
-        /// </param>
-        /// <returns>
-        /// The instantiated <see cref="TypeConverter"/>.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">
-        /// Thrown if <paramref name="converterTypeName"/> does not correspond
-        /// to a <see cref="TypeConverter"/>.
-        /// </exception>
-        private static TypeConverter GetTypeConverterFromName(string converterTypeName)
+        throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConversionUnsupported, value.GetType(), destinationType));
+    }
+
+    /// <summary>
+    /// Instantiates a type converter from its type name.
+    /// </summary>
+    /// <param name="converterTypeName">
+    /// The name of the <see cref="Type"/> of the <see cref="TypeConverter"/>.
+    /// </param>
+    /// <returns>
+    /// The instantiated <see cref="TypeConverter"/>.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <paramref name="converterTypeName"/> does not correspond
+    /// to a <see cref="TypeConverter"/>.
+    /// </exception>
+    private static TypeConverter GetTypeConverterFromName(string converterTypeName)
+    {
+        var converterType = Type.GetType(converterTypeName, true);
+        if (!(Activator.CreateInstance(converterType) is TypeConverter converter))
         {
-            var converterType = Type.GetType(converterTypeName, true);
-            if (!(Activator.CreateInstance(converterType) is TypeConverter converter))
-            {
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConverterAttributeTypeNotConverter, converterTypeName));
-            }
-
-            return converter;
+            throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConverterAttributeTypeNotConverter, converterTypeName));
         }
+
+        return converter;
     }
 }

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 
 namespace Autofac.Configuration.Util

--- a/test/Autofac.Configuration.Test/AssertionHelpers.cs
+++ b/test/Autofac.Configuration.Test/AssertionHelpers.cs
@@ -1,28 +1,27 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Configuration.Test
+namespace Autofac.Configuration.Test;
+
+internal static class AssertionHelpers
 {
-    internal static class AssertionHelpers
+    public static void AssertRegistered<TService>(this IComponentContext context, string message = "Expected component was not registered.")
     {
-        public static void AssertRegistered<TService>(this IComponentContext context, string message = "Expected component was not registered.")
-        {
-            Assert.True(context.IsRegistered<TService>(), message);
-        }
+        Assert.True(context.IsRegistered<TService>(), message);
+    }
 
-        public static void AssertNotRegistered<TService>(this IComponentContext context, string message = "Component was registered unexpectedly.")
-        {
-            Assert.False(context.IsRegistered<TService>(), message);
-        }
+    public static void AssertNotRegistered<TService>(this IComponentContext context, string message = "Component was registered unexpectedly.")
+    {
+        Assert.False(context.IsRegistered<TService>(), message);
+    }
 
-        public static void AssertRegisteredNamed<TService>(this IComponentContext context, string service, string message = "Expected named component was not registered.")
-        {
-            Assert.True(context.IsRegisteredWithName(service, typeof(TService)), message);
-        }
+    public static void AssertRegisteredNamed<TService>(this IComponentContext context, string service, string message = "Expected named component was not registered.")
+    {
+        Assert.True(context.IsRegisteredWithName(service, typeof(TService)), message);
+    }
 
-        public static void AssertNotRegisteredNamed<TService>(this IComponentContext context, string service, string message = "Named component was registered unexpectedly.")
-        {
-            Assert.False(context.IsRegisteredWithName(service, typeof(TService)), message);
-        }
+    public static void AssertNotRegisteredNamed<TService>(this IComponentContext context, string service, string message = "Named component was registered unexpectedly.")
+    {
+        Assert.False(context.IsRegisteredWithName(service, typeof(TService)), message);
     }
 }

--- a/test/Autofac.Configuration.Test/AssertionHelpers.cs
+++ b/test/Autofac.Configuration.Test/AssertionHelpers.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Xunit;
-
 namespace Autofac.Configuration.Test
 {
     internal static class AssertionHelpers

--- a/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
+++ b/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
@@ -1,16 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <NoWarn>$(NoWarn);CS1591;SA1600;SA1602;SA1611</NoWarn>
+    <TargetFramework>net6.0</TargetFramework>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Moq" />
+    <Using Include="Xunit" />
+  </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
@@ -48,16 +55,27 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
-      <PrivateAssets>All</PrivateAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.406">
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
+++ b/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Include="System.Diagnostics.CodeAnalysis" />
     <Using Include="Moq" />
     <Using Include="Xunit" />
   </ItemGroup>

--- a/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
@@ -3,182 +3,181 @@
 
 using Autofac.Core;
 
-namespace Autofac.Configuration.Test.Core
+namespace Autofac.Configuration.Test.Core;
+
+public class ComponentRegistrarFixture
 {
-    public class ComponentRegistrarFixture
+    [Fact]
+    public void RegisterConfiguredComponents_AllowsMultipleRegistrationsOfSameType()
     {
-        [Fact]
-        public void RegisterConfiguredComponents_AllowsMultipleRegistrationsOfSameType()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_SameTypeRegisteredMultipleTimes.json");
-            var container = builder.Build();
-            var collection = container.Resolve<IEnumerable<SimpleComponent>>();
-            Assert.Equal(2, collection.Count());
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_SameTypeRegisteredMultipleTimes.json");
+        var container = builder.Build();
+        var collection = container.Resolve<IEnumerable<SimpleComponent>>();
+        Assert.Equal(2, collection.Count());
 
-            // Test using Any() because we aren't necessarily guaranteed the order of resolution.
-            Assert.True(collection.Any(a => a.Input == 5.123), "The first registration (5.123) wasn't found.");
-            Assert.True(collection.Any(a => a.Input == 10.234), "The second registration (10.234) wasn't found.");
+        // Test using Any() because we aren't necessarily guaranteed the order of resolution.
+        Assert.True(collection.Any(a => a.Input == 5.123), "The first registration (5.123) wasn't found.");
+        Assert.True(collection.Any(a => a.Input == 10.234), "The second registration (10.234) wasn't found.");
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_AutoActivationEnabledOnComponent()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_EnableAutoActivation.json");
+        var container = builder.Build();
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new KeyedService("a", typeof(object)), out IComponentRegistration registration), "The expected component was not registered.");
+        Assert.True(registration.Services.Any(a => a.GetType().Name == "AutoActivateService"), "Auto activate service was not registered on the component");
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_AutoActivationNotEnabledOnComponent()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_EnableAutoActivation.json");
+        var container = builder.Build();
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new KeyedService("b", typeof(object)), out IComponentRegistration registration), "The expected component was not registered.");
+        Assert.False(registration.Services.Any(a => a.GetType().Name == "AutoActivateService"), "Auto activate service was registered on the component when it shouldn't be.");
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_ConstructorInjection()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
+        var container = builder.Build();
+        var cpt = (SimpleComponent)container.Resolve<ITestComponent>();
+        Assert.Equal(1.234, cpt.Input);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_ExternalOwnership()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_ExternalOwnership.json");
+        var container = builder.Build();
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(SimpleComponent)), out IComponentRegistration registration), "The expected component was not registered.");
+        Assert.Equal(InstanceOwnership.ExternallyOwned, registration.Ownership);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_LifetimeScope_InstancePerDependency()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_InstancePerDependency.json");
+        var container = builder.Build();
+        Assert.NotSame(container.Resolve<SimpleComponent>(), container.Resolve<SimpleComponent>());
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_LifetimeScope_Singleton()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
+        var container = builder.Build();
+        Assert.Same(container.Resolve<ITestComponent>(), container.Resolve<ITestComponent>());
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_PropertyInjectionEnabledOnComponent()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_EnablePropertyInjection.json");
+        builder.RegisterType<SimpleComponent>().As<ITestComponent>();
+        builder.RegisterInstance("hello").As<string>();
+        var container = builder.Build();
+        var e = container.Resolve<ComponentConsumer>();
+        Assert.NotNull(e.Component);
+
+        // Issue #2 - Ensure properties in base classes can be set by config.
+        Assert.Equal("hello", e.Message);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_PropertyInjectionWithProvidedValues()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
+        var container = builder.Build();
+        var cpt = (SimpleComponent)container.Resolve<ITestComponent>();
+        Assert.True(cpt.ABool, "The Boolean property value was not properly parsed/converted.");
+
+        // Issue #2 - Ensure properties in base classes can be set by config.
+        Assert.Equal("hello", cpt.Message);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_RegistersMetadata()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_ComponentWithMetadata.json");
+        var container = builder.Build();
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new KeyedService("a", typeof(object)), out IComponentRegistration registration), "The expected service wasn't registered.");
+        Assert.Equal(42.42, (double)registration.Metadata["answer"]);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_SingleComponentWithTwoServices()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
+        var container = builder.Build();
+        container.AssertRegistered<ITestComponent>("The ITestComponent wasn't registered.");
+        container.AssertRegistered<object>("The object wasn't registered.");
+        container.AssertNotRegistered<SimpleComponent>("The base SimpleComponent type was incorrectly registered.");
+        Assert.Same(container.Resolve<ITestComponent>(), container.Resolve<object>());
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_ComponentsMissingName()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_ComponentsMissingName.xml");
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("The 'components' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_ServicesMissingName()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_ServicesMissingName.xml");
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("The 'services' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components:0:services' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_MetadataMissingName()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_MetadataMissingName.xml");
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("The 'metadata' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components:0:metadata' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ComponentConsumer : BaseComponentConsumer
+    {
+        public ITestComponent Component { get; set; }
+    }
+
+    private class BaseComponentConsumer
+    {
+        // Issue #2 - Ensure properties in base classes can be set by config.
+        public string Message { get; set; }
+    }
+
+    private interface ITestComponent
+    {
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class SimpleComponent : BaseComponent, ITestComponent
+    {
+        public SimpleComponent()
+        {
         }
 
-        [Fact]
-        public void RegisterConfiguredComponents_AutoActivationEnabledOnComponent()
+        public SimpleComponent(double input)
         {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_EnableAutoActivation.json");
-            var container = builder.Build();
-            Assert.True(container.ComponentRegistry.TryGetRegistration(new KeyedService("a", typeof(object)), out IComponentRegistration registration), "The expected component was not registered.");
-            Assert.True(registration.Services.Any(a => a.GetType().Name == "AutoActivateService"), "Auto activate service was not registered on the component");
+            Input = input;
         }
 
-        [Fact]
-        public void RegisterConfiguredComponents_AutoActivationNotEnabledOnComponent()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_EnableAutoActivation.json");
-            var container = builder.Build();
-            Assert.True(container.ComponentRegistry.TryGetRegistration(new KeyedService("b", typeof(object)), out IComponentRegistration registration), "The expected component was not registered.");
-            Assert.False(registration.Services.Any(a => a.GetType().Name == "AutoActivateService"), "Auto activate service was registered on the component when it shouldn't be.");
-        }
+        public bool ABool { get; set; }
 
-        [Fact]
-        public void RegisterConfiguredComponents_ConstructorInjection()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
-            var container = builder.Build();
-            var cpt = (SimpleComponent)container.Resolve<ITestComponent>();
-            Assert.Equal(1.234, cpt.Input);
-        }
+        public double Input { get; set; }
+    }
 
-        [Fact]
-        public void RegisterConfiguredComponents_ExternalOwnership()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_ExternalOwnership.json");
-            var container = builder.Build();
-            Assert.True(container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(SimpleComponent)), out IComponentRegistration registration), "The expected component was not registered.");
-            Assert.Equal(InstanceOwnership.ExternallyOwned, registration.Ownership);
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_LifetimeScope_InstancePerDependency()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_InstancePerDependency.json");
-            var container = builder.Build();
-            Assert.NotSame(container.Resolve<SimpleComponent>(), container.Resolve<SimpleComponent>());
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_LifetimeScope_Singleton()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
-            var container = builder.Build();
-            Assert.Same(container.Resolve<ITestComponent>(), container.Resolve<ITestComponent>());
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_PropertyInjectionEnabledOnComponent()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_EnablePropertyInjection.json");
-            builder.RegisterType<SimpleComponent>().As<ITestComponent>();
-            builder.RegisterInstance("hello").As<string>();
-            var container = builder.Build();
-            var e = container.Resolve<ComponentConsumer>();
-            Assert.NotNull(e.Component);
-
-            // Issue #2 - Ensure properties in base classes can be set by config.
-            Assert.Equal("hello", e.Message);
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_PropertyInjectionWithProvidedValues()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
-            var container = builder.Build();
-            var cpt = (SimpleComponent)container.Resolve<ITestComponent>();
-            Assert.True(cpt.ABool, "The Boolean property value was not properly parsed/converted.");
-
-            // Issue #2 - Ensure properties in base classes can be set by config.
-            Assert.Equal("hello", cpt.Message);
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_RegistersMetadata()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_ComponentWithMetadata.json");
-            var container = builder.Build();
-            Assert.True(container.ComponentRegistry.TryGetRegistration(new KeyedService("a", typeof(object)), out IComponentRegistration registration), "The expected service wasn't registered.");
-            Assert.Equal(42.42, (double)registration.Metadata["answer"]);
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_SingleComponentWithTwoServices()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_SingletonWithTwoServices.xml");
-            var container = builder.Build();
-            container.AssertRegistered<ITestComponent>("The ITestComponent wasn't registered.");
-            container.AssertRegistered<object>("The object wasn't registered.");
-            container.AssertNotRegistered<SimpleComponent>("The base SimpleComponent type was incorrectly registered.");
-            Assert.Same(container.Resolve<ITestComponent>(), container.Resolve<object>());
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_ComponentsMissingName()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_ComponentsMissingName.xml");
-            var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("The 'components' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_ServicesMissingName()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_ServicesMissingName.xml");
-            var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("The 'services' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components:0:services' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
-        }
-
-        [Fact]
-        public void RegisterConfiguredComponents_MetadataMissingName()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ComponentRegistrar_MetadataMissingName.xml");
-            var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("The 'metadata' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components:0:metadata' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ComponentConsumer : BaseComponentConsumer
-        {
-            public ITestComponent Component { get; set; }
-        }
-
-        private class BaseComponentConsumer
-        {
-            // Issue #2 - Ensure properties in base classes can be set by config.
-            public string Message { get; set; }
-        }
-
-        private interface ITestComponent
-        {
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class SimpleComponent : BaseComponent, ITestComponent
-        {
-            public SimpleComponent()
-            {
-            }
-
-            public SimpleComponent(double input)
-            {
-                Input = input;
-            }
-
-            public bool ABool { get; set; }
-
-            public double Input { get; set; }
-        }
-
-        private class BaseComponent
-        {
-            // Issue #2 - Ensure properties in base classes can be set by config.
-            public string Message { get; set; }
-        }
+    private class BaseComponent
+    {
+        // Issue #2 - Ensure properties in base classes can be set by config.
+        public string Message { get; set; }
     }
 }

--- a/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Autofac.Core;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Core
 {

--- a/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
@@ -146,6 +146,7 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("The 'metadata' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'components:0:metadata' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ComponentConsumer : BaseComponentConsumer
         {
             public ITestComponent Component { get; set; }
@@ -161,6 +162,7 @@ namespace Autofac.Configuration.Test.Core
         {
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class SimpleComponent : BaseComponent, ITestComponent
         {
             public SimpleComponent()

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
@@ -10,407 +10,406 @@ using Autofac.Configuration.Util;
 using Autofac.Core;
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration.Test.Core
+namespace Autofac.Configuration.Test.Core;
+
+public class ConfigurationExtensionsFixture
 {
-    public class ConfigurationExtensionsFixture
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void DefaultAssembly_AssemblyNameEmpty(string value)
     {
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void DefaultAssembly_AssemblyNameEmpty(string value)
+        var config = SetUpDefaultAssembly(value);
+        Assert.Null(config.DefaultAssembly());
+    }
+
+    [Fact]
+    public void DefaultAssembly_AssemblyNameMissing()
+    {
+        var config = new ConfigurationBuilder().Build();
+        Assert.Null(config.DefaultAssembly());
+    }
+
+    [Fact]
+    public void DefaultAssembly_AssemblyNotFound()
+    {
+        var config = SetUpDefaultAssembly("NoSuchAssembly");
+        Assert.Throws<FileNotFoundException>(() => config.DefaultAssembly());
+    }
+
+    [Fact]
+    public void DefaultAssembly_FullAssemblyName()
+    {
+        var expected = typeof(string).GetTypeInfo().Assembly;
+        var config = SetUpDefaultAssembly(expected.FullName);
+        Assert.Equal(expected, config.DefaultAssembly());
+    }
+
+    [Fact]
+    public void DefaultAssembly_NullConfiguration()
+    {
+        var config = (IConfiguration)null;
+        Assert.Throws<ArgumentNullException>(() => config.DefaultAssembly());
+    }
+
+    [Fact]
+    public void DefaultAssembly_SimpleAssemblyName()
+    {
+        // String is in a different assembly depending on the
+        // target framework. We have to calculate it and truncate
+        // the full assembly name at the first comma.
+        var expected = typeof(string).GetTypeInfo().Assembly;
+        var fullName = expected.FullName.Substring(0, expected.FullName.IndexOf(',', StringComparison.Ordinal));
+        var config = SetUpDefaultAssembly(fullName);
+        Assert.Equal(expected, config.DefaultAssembly());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetAssembly_EmptyKey(string key)
+    {
+        var config = new ConfigurationBuilder().Build();
+        Assert.Throws<ArgumentException>(() => config.GetAssembly(key));
+    }
+
+    [Fact]
+    public void GetAssembly_NullConfiguration()
+    {
+        var config = (IConfiguration)null;
+        Assert.Throws<ArgumentNullException>(() => config.GetAssembly("defaultAssembly"));
+    }
+
+    [Fact]
+    public void GetAssembly_NullKey()
+    {
+        var config = new ConfigurationBuilder().Build();
+        Assert.Throws<ArgumentNullException>(() => config.GetAssembly(null));
+    }
+
+    [Fact]
+    public void GetParameters_ListParameterPopulated()
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableParameter).FullName).First();
+        var objectParameter = typeof(HasEnumerableParameter).GetConstructors().First().GetParameters().First(pi => pi.Name == "list");
+        var provider = (Func<object>)null;
+        var parameter = component.GetParameters("parameters").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(objectParameter, new ContainerBuilder().Build(), out provider));
+        Assert.NotNull(parameter);
+        Assert.NotNull(provider);
+        Assert.Equal(new List<string> { "a", "b" }, provider());
+    }
+
+    [Fact]
+    public void GetParameters_ParameterConversionUsesTypeConverterAttribute()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
+        var obj = container.Resolve<HasConvertibleParametersAndProperties>();
+        Assert.NotNull(obj.Parameter);
+        Assert.Equal(1.234, obj.Parameter.Value);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetParameters_SimpleParameters_Source))]
+    public void GetParameters_SimpleParameters(string parameterName, object expectedValue)
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName).First();
+        var objectParameter = typeof(HasSimpleParametersAndProperties).GetConstructors().First().GetParameters().First(pi => pi.Name == parameterName);
+        var provider = (Func<object>)null;
+        var parameter = component.GetParameters("parameters").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(objectParameter, new ContainerBuilder().Build(), out provider));
+        Assert.NotNull(parameter);
+        Assert.NotNull(provider);
+        Assert.Equal(expectedValue, provider());
+    }
+
+    [Fact]
+    public void GetProperties_DictionaryPropertyEmpty()
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName).First();
+        var property = typeof(HasDictionaryProperty).GetProperty("Empty");
+        var provider = (Func<object>)null;
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+
+        // Gotcha in ConfigurationModel - if the list/dictionary is empty
+        // then configuration won't see it or add the key to the list.
+        Assert.Null(parameter);
+    }
+
+    [Fact]
+    public void GetProperties_DictionaryPropertyPopulated()
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName).First();
+        var property = typeof(HasDictionaryProperty).GetProperty("Populated");
+        var provider = (Func<object>)null;
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        Assert.NotNull(parameter);
+        Assert.NotNull(provider);
+        var value = provider();
+        Assert.NotNull(value);
+        var dict = Assert.IsType<Dictionary<string, double>>(value);
+        Assert.Equal(1.234, dict["a"]);
+        Assert.Equal(2.345, dict["b"]);
+    }
+
+    [Fact]
+    public void GetProperties_DictionaryPropertyUsesTypeConverterAttribute()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
+        var obj = container.Resolve<HasDictionaryProperty>();
+        Assert.NotNull(obj.Convertible);
+        Assert.Equal(2, obj.Convertible.Count);
+        Assert.Equal(1.234, obj.Convertible["a"].Value);
+        Assert.Equal(2.345, obj.Convertible["b"].Value);
+    }
+
+    [Fact]
+    public void GetProperties_ListConversionUsesTypeConverterAttribute()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
+        var obj = container.Resolve<HasEnumerableProperty>();
+        Assert.NotNull(obj.Convertible);
+        var convertible = obj.Convertible.ToArray();
+        Assert.Equal(2, convertible.Length);
+        Assert.Equal(1.234, convertible[0].Value);
+        Assert.Equal(2.345, convertible[1].Value);
+    }
+
+    [Fact]
+    public void GetProperties_ListPropertyEmpty()
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName).First();
+        var property = typeof(HasEnumerableProperty).GetProperty("Empty");
+        var provider = (Func<object>)null;
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+
+        // Gotcha in ConfigurationModel - if the list/dictionary is empty
+        // then configuration won't see it or add the key to the list.
+        Assert.Null(parameter);
+    }
+
+    [Fact]
+    public void GetProperties_ListPropertyPopulated()
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName).First();
+        var property = typeof(HasEnumerableProperty).GetProperty("Populated");
+        var provider = (Func<object>)null;
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        Assert.NotNull(parameter);
+        Assert.NotNull(provider);
+        Assert.Equal(new List<double> { 1.234, 2.345 }, provider());
+    }
+
+    [Fact]
+    public void GetProperties_PropertyConversionUsesTypeConverterAttribute()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
+        var obj = container.Resolve<HasConvertibleParametersAndProperties>();
+        Assert.NotNull(obj.Property);
+        Assert.Equal(2.345, obj.Property.Value);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetProperties_SimpleProperties_Source))]
+    public void GetProperties_SimpleProperties(string propertyName, object expectedValue)
+    {
+        var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
+        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName).First();
+        var property = typeof(HasSimpleParametersAndProperties).GetProperties().First(pi => pi.Name == propertyName);
+        var provider = (Func<object>)null;
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        Assert.NotNull(parameter);
+        Assert.NotNull(provider);
+        Assert.Equal(expectedValue, provider());
+    }
+
+    public static IEnumerable<object[]> GetParameters_SimpleParameters_Source()
+    {
+        yield return new object[] { "number", 1.234 };
+        yield return new object[] { "ip", IPAddress.Parse("127.0.0.1") };
+    }
+
+    [SuppressMessage("CA1024", "CA1024", Justification = "Data sources must be methods.")]
+    public static IEnumerable<object[]> GetProperties_SimpleProperties_Source()
+    {
+        yield return new object[] { "Text", "text" };
+        yield return new object[] { "Url", new Uri("http://localhost") };
+    }
+
+    private static IConfiguration SetUpDefaultAssembly(string assemblyName)
+    {
+        var data = new Dictionary<string, string>
         {
-            var config = SetUpDefaultAssembly(value);
-            Assert.Null(config.DefaultAssembly());
+            { "defaultAssembly", assemblyName },
+        };
+        return new ConfigurationBuilder().AddInMemoryCollection(data).Build();
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class BaseSimpleParametersAndProperties
+    {
+        // Issue #2 - Ensure properties in base classes can be set by config.
+        public string Text { get; set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class Convertible
+    {
+        public double Value { get; set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ConvertibleConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
         }
 
-        [Fact]
-        public void DefaultAssembly_AssemblyNameMissing()
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            var config = new ConfigurationBuilder().Build();
-            Assert.Null(config.DefaultAssembly());
-        }
-
-        [Fact]
-        public void DefaultAssembly_AssemblyNotFound()
-        {
-            var config = SetUpDefaultAssembly("NoSuchAssembly");
-            Assert.Throws<FileNotFoundException>(() => config.DefaultAssembly());
-        }
-
-        [Fact]
-        public void DefaultAssembly_FullAssemblyName()
-        {
-            var expected = typeof(string).GetTypeInfo().Assembly;
-            var config = SetUpDefaultAssembly(expected.FullName);
-            Assert.Equal(expected, config.DefaultAssembly());
-        }
-
-        [Fact]
-        public void DefaultAssembly_NullConfiguration()
-        {
-            var config = (IConfiguration)null;
-            Assert.Throws<ArgumentNullException>(() => config.DefaultAssembly());
-        }
-
-        [Fact]
-        public void DefaultAssembly_SimpleAssemblyName()
-        {
-            // String is in a different assembly depending on the
-            // target framework. We have to calculate it and truncate
-            // the full assembly name at the first comma.
-            var expected = typeof(string).GetTypeInfo().Assembly;
-            var fullName = expected.FullName.Substring(0, expected.FullName.IndexOf(',', StringComparison.Ordinal));
-            var config = SetUpDefaultAssembly(fullName);
-            Assert.Equal(expected, config.DefaultAssembly());
-        }
-
-        [Theory]
-        [InlineData("")]
-        [InlineData("   ")]
-        public void GetAssembly_EmptyKey(string key)
-        {
-            var config = new ConfigurationBuilder().Build();
-            Assert.Throws<ArgumentException>(() => config.GetAssembly(key));
-        }
-
-        [Fact]
-        public void GetAssembly_NullConfiguration()
-        {
-            var config = (IConfiguration)null;
-            Assert.Throws<ArgumentNullException>(() => config.GetAssembly("defaultAssembly"));
-        }
-
-        [Fact]
-        public void GetAssembly_NullKey()
-        {
-            var config = new ConfigurationBuilder().Build();
-            Assert.Throws<ArgumentNullException>(() => config.GetAssembly(null));
-        }
-
-        [Fact]
-        public void GetParameters_ListParameterPopulated()
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableParameter).FullName).First();
-            var objectParameter = typeof(HasEnumerableParameter).GetConstructors().First().GetParameters().First(pi => pi.Name == "list");
-            var provider = (Func<object>)null;
-            var parameter = component.GetParameters("parameters").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(objectParameter, new ContainerBuilder().Build(), out provider));
-            Assert.NotNull(parameter);
-            Assert.NotNull(provider);
-            Assert.Equal(new List<string> { "a", "b" }, provider());
-        }
-
-        [Fact]
-        public void GetParameters_ParameterConversionUsesTypeConverterAttribute()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
-            var obj = container.Resolve<HasConvertibleParametersAndProperties>();
-            Assert.NotNull(obj.Parameter);
-            Assert.Equal(1.234, obj.Parameter.Value);
-        }
-
-        [Theory]
-        [MemberData(nameof(GetParameters_SimpleParameters_Source))]
-        public void GetParameters_SimpleParameters(string parameterName, object expectedValue)
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName).First();
-            var objectParameter = typeof(HasSimpleParametersAndProperties).GetConstructors().First().GetParameters().First(pi => pi.Name == parameterName);
-            var provider = (Func<object>)null;
-            var parameter = component.GetParameters("parameters").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(objectParameter, new ContainerBuilder().Build(), out provider));
-            Assert.NotNull(parameter);
-            Assert.NotNull(provider);
-            Assert.Equal(expectedValue, provider());
-        }
-
-        [Fact]
-        public void GetProperties_DictionaryPropertyEmpty()
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName).First();
-            var property = typeof(HasDictionaryProperty).GetProperty("Empty");
-            var provider = (Func<object>)null;
-            var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
-
-            // Gotcha in ConfigurationModel - if the list/dictionary is empty
-            // then configuration won't see it or add the key to the list.
-            Assert.Null(parameter);
-        }
-
-        [Fact]
-        public void GetProperties_DictionaryPropertyPopulated()
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName).First();
-            var property = typeof(HasDictionaryProperty).GetProperty("Populated");
-            var provider = (Func<object>)null;
-            var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
-            Assert.NotNull(parameter);
-            Assert.NotNull(provider);
-            var value = provider();
-            Assert.NotNull(value);
-            var dict = Assert.IsType<Dictionary<string, double>>(value);
-            Assert.Equal(1.234, dict["a"]);
-            Assert.Equal(2.345, dict["b"]);
-        }
-
-        [Fact]
-        public void GetProperties_DictionaryPropertyUsesTypeConverterAttribute()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
-            var obj = container.Resolve<HasDictionaryProperty>();
-            Assert.NotNull(obj.Convertible);
-            Assert.Equal(2, obj.Convertible.Count);
-            Assert.Equal(1.234, obj.Convertible["a"].Value);
-            Assert.Equal(2.345, obj.Convertible["b"].Value);
-        }
-
-        [Fact]
-        public void GetProperties_ListConversionUsesTypeConverterAttribute()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
-            var obj = container.Resolve<HasEnumerableProperty>();
-            Assert.NotNull(obj.Convertible);
-            var convertible = obj.Convertible.ToArray();
-            Assert.Equal(2, convertible.Length);
-            Assert.Equal(1.234, convertible[0].Value);
-            Assert.Equal(2.345, convertible[1].Value);
-        }
-
-        [Fact]
-        public void GetProperties_ListPropertyEmpty()
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName).First();
-            var property = typeof(HasEnumerableProperty).GetProperty("Empty");
-            var provider = (Func<object>)null;
-            var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
-
-            // Gotcha in ConfigurationModel - if the list/dictionary is empty
-            // then configuration won't see it or add the key to the list.
-            Assert.Null(parameter);
-        }
-
-        [Fact]
-        public void GetProperties_ListPropertyPopulated()
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName).First();
-            var property = typeof(HasEnumerableProperty).GetProperty("Populated");
-            var provider = (Func<object>)null;
-            var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
-            Assert.NotNull(parameter);
-            Assert.NotNull(provider);
-            Assert.Equal(new List<double> { 1.234, 2.345 }, provider());
-        }
-
-        [Fact]
-        public void GetProperties_PropertyConversionUsesTypeConverterAttribute()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithJson("ConfigurationExtensions_Parameters.json").Build();
-            var obj = container.Resolve<HasConvertibleParametersAndProperties>();
-            Assert.NotNull(obj.Property);
-            Assert.Equal(2.345, obj.Property.Value);
-        }
-
-        [Theory]
-        [MemberData(nameof(GetProperties_SimpleProperties_Source))]
-        public void GetProperties_SimpleProperties(string propertyName, object expectedValue)
-        {
-            var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-            var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName).First();
-            var property = typeof(HasSimpleParametersAndProperties).GetProperties().First(pi => pi.Name == propertyName);
-            var provider = (Func<object>)null;
-            var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
-            Assert.NotNull(parameter);
-            Assert.NotNull(provider);
-            Assert.Equal(expectedValue, provider());
-        }
-
-        public static IEnumerable<object[]> GetParameters_SimpleParameters_Source()
-        {
-            yield return new object[] { "number", 1.234 };
-            yield return new object[] { "ip", IPAddress.Parse("127.0.0.1") };
-        }
-
-        [SuppressMessage("CA1024", "CA1024", Justification = "Data sources must be methods.")]
-        public static IEnumerable<object[]> GetProperties_SimpleProperties_Source()
-        {
-            yield return new object[] { "Text", "text" };
-            yield return new object[] { "Url", new Uri("http://localhost") };
-        }
-
-        private static IConfiguration SetUpDefaultAssembly(string assemblyName)
-        {
-            var data = new Dictionary<string, string>
+            if (value == null)
             {
-                { "defaultAssembly", assemblyName },
-            };
-            return new ConfigurationBuilder().AddInMemoryCollection(data).Build();
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class BaseSimpleParametersAndProperties
-        {
-            // Issue #2 - Ensure properties in base classes can be set by config.
-            public string Text { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class Convertible
-        {
-            public double Value { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ConvertibleConverter : TypeConverter
-        {
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-            {
-                return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+                return null;
             }
 
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            if (value is not string str)
             {
-                if (value == null)
-                {
-                    return null;
-                }
-
-                if (value is not string str)
-                {
-                    return base.ConvertFrom(context, culture, value);
-                }
-
-                var converter = TypeDescriptor.GetConverter(typeof(double));
-                return new Convertible { Value = (double)converter.ConvertFromString(context, culture, str) };
+                return base.ConvertFrom(context, culture, value);
             }
-        }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ConvertibleDictionaryConverter : TypeConverter
+            var converter = TypeDescriptor.GetConverter(typeof(double));
+            return new Convertible { Value = (double)converter.ConvertFromString(context, culture, str) };
+        }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ConvertibleDictionaryConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
         {
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-            {
-                return sourceType == typeof(ConfiguredDictionaryParameter) || base.CanConvertFrom(context, sourceType);
-            }
-
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-            {
-                if (value == null)
-                {
-                    return null;
-                }
-
-                if (value is not ConfiguredDictionaryParameter castValue)
-                {
-                    return base.ConvertFrom(context, culture, value);
-                }
-
-                var dict = new Dictionary<string, Convertible>();
-                var converter = new ConvertibleConverter();
-                foreach (var item in castValue.Dictionary)
-                {
-                    dict[item.Key] = (Convertible)converter.ConvertFrom(item.Value);
-                }
-
-                return dict;
-            }
+            return sourceType == typeof(ConfiguredDictionaryParameter) || base.CanConvertFrom(context, sourceType);
         }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ConvertibleListConverter : TypeConverter
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+            if (value == null)
             {
-                return sourceType == typeof(ConfiguredListParameter) || base.CanConvertFrom(context, sourceType);
+                return null;
             }
 
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            if (value is not ConfiguredDictionaryParameter castValue)
             {
-                if (value == null)
-                {
-                    return null;
-                }
-
-                if (value is not ConfiguredListParameter castValue)
-                {
-                    return base.ConvertFrom(context, culture, value);
-                }
-
-                var list = new List<Convertible>();
-                var converter = new ConvertibleConverter();
-                foreach (string item in castValue.List)
-                {
-                    list.Add((Convertible)converter.ConvertFrom(item));
-                }
-
-                return list;
-            }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasConvertibleParametersAndProperties
-        {
-            public HasConvertibleParametersAndProperties([TypeConverter(typeof(ConvertibleConverter))] Convertible parameter)
-            {
-                Parameter = parameter;
+                return base.ConvertFrom(context, culture, value);
             }
 
-            public Convertible Parameter { get; set; }
-
-            [TypeConverter(typeof(ConvertibleConverter))]
-            public Convertible Property { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasDictionaryProperty
-        {
-            [TypeConverter(typeof(ConvertibleDictionaryConverter))]
-            public IDictionary<string, Convertible> Convertible { get; set; }
-
-            public Dictionary<string, double> Empty { get; set; }
-
-            public Dictionary<string, double> Populated { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasEnumerableParameter
-        {
-            public HasEnumerableParameter(IList<string> list)
+            var dict = new Dictionary<string, Convertible>();
+            var converter = new ConvertibleConverter();
+            foreach (var item in castValue.Dictionary)
             {
-                List = list;
+                dict[item.Key] = (Convertible)converter.ConvertFrom(item.Value);
             }
 
-            public IList<string> List { get; private set; }
+            return dict;
+        }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ConvertibleListConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(ConfiguredListParameter) || base.CanConvertFrom(context, sourceType);
         }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasEnumerableProperty
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            [TypeConverter(typeof(ConvertibleListConverter))]
-            public IEnumerable<Convertible> Convertible { get; set; }
-
-            public IEnumerable<double> Empty { get; set; }
-
-            public IEnumerable<double> Populated { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasSimpleParametersAndProperties : BaseSimpleParametersAndProperties
-        {
-            public HasSimpleParametersAndProperties(double number, IPAddress ip)
+            if (value == null)
             {
-                Number = number;
-                IP = ip;
+                return null;
             }
 
-            public IPAddress IP { get; private set; }
+            if (value is not ConfiguredListParameter castValue)
+            {
+                return base.ConvertFrom(context, culture, value);
+            }
 
-            public double Number { get; private set; }
+            var list = new List<Convertible>();
+            var converter = new ConvertibleConverter();
+            foreach (string item in castValue.List)
+            {
+                list.Add((Convertible)converter.ConvertFrom(item));
+            }
 
-            public Uri Url { get; set; }
+            return list;
         }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasConvertibleParametersAndProperties
+    {
+        public HasConvertibleParametersAndProperties([TypeConverter(typeof(ConvertibleConverter))] Convertible parameter)
+        {
+            Parameter = parameter;
+        }
+
+        public Convertible Parameter { get; set; }
+
+        [TypeConverter(typeof(ConvertibleConverter))]
+        public Convertible Property { get; set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasDictionaryProperty
+    {
+        [TypeConverter(typeof(ConvertibleDictionaryConverter))]
+        public IDictionary<string, Convertible> Convertible { get; set; }
+
+        public Dictionary<string, double> Empty { get; set; }
+
+        public Dictionary<string, double> Populated { get; set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasEnumerableParameter
+    {
+        public HasEnumerableParameter(IList<string> list)
+        {
+            List = list;
+        }
+
+        public IList<string> List { get; private set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasEnumerableProperty
+    {
+        [TypeConverter(typeof(ConvertibleListConverter))]
+        public IEnumerable<Convertible> Convertible { get; set; }
+
+        public IEnumerable<double> Empty { get; set; }
+
+        public IEnumerable<double> Populated { get; set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasSimpleParametersAndProperties : BaseSimpleParametersAndProperties
+    {
+        public HasSimpleParametersAndProperties(double number, IPAddress ip)
+        {
+            Number = number;
+            IP = ip;
+        }
+
+        public IPAddress IP { get; private set; }
+
+        public double Number { get; private set; }
+
+        public Uri Url { get; set; }
     }
 }

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Reflection;
 using Autofac.Configuration.Core;
 using Autofac.Configuration.Util;
 using Autofac.Core;
 using Microsoft.Extensions.Configuration;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Core
 {

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
@@ -65,7 +65,7 @@ namespace Autofac.Configuration.Test.Core
             // target framework. We have to calculate it and truncate
             // the full assembly name at the first comma.
             var expected = typeof(string).GetTypeInfo().Assembly;
-            var fullName = expected.FullName.Substring(0, expected.FullName.IndexOf(','));
+            var fullName = expected.FullName.Substring(0, expected.FullName.IndexOf(',', StringComparison.Ordinal));
             var config = SetUpDefaultAssembly(fullName);
             Assert.Equal(expected, config.DefaultAssembly());
         }
@@ -239,6 +239,7 @@ namespace Autofac.Configuration.Test.Core
             yield return new object[] { "ip", IPAddress.Parse("127.0.0.1") };
         }
 
+        [SuppressMessage("CA1024", "CA1024", Justification = "Data sources must be methods.")]
         public static IEnumerable<object[]> GetProperties_SimpleProperties_Source()
         {
             yield return new object[] { "Text", "text" };
@@ -254,18 +255,21 @@ namespace Autofac.Configuration.Test.Core
             return new ConfigurationBuilder().AddInMemoryCollection(data).Build();
         }
 
-        public class BaseSimpleParametersAndProperties
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class BaseSimpleParametersAndProperties
         {
             // Issue #2 - Ensure properties in base classes can be set by config.
             public string Text { get; set; }
         }
 
-        public class Convertible
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class Convertible
         {
             public double Value { get; set; }
         }
 
-        public class ConvertibleConverter : TypeConverter
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class ConvertibleConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {
@@ -279,7 +283,7 @@ namespace Autofac.Configuration.Test.Core
                     return null;
                 }
 
-                if (!(value is string str))
+                if (value is not string str)
                 {
                     return base.ConvertFrom(context, culture, value);
                 }
@@ -289,7 +293,8 @@ namespace Autofac.Configuration.Test.Core
             }
         }
 
-        public class ConvertibleDictionaryConverter : TypeConverter
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class ConvertibleDictionaryConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {
@@ -303,7 +308,7 @@ namespace Autofac.Configuration.Test.Core
                     return null;
                 }
 
-                if (!(value is ConfiguredDictionaryParameter castValue))
+                if (value is not ConfiguredDictionaryParameter castValue)
                 {
                     return base.ConvertFrom(context, culture, value);
                 }
@@ -319,7 +324,8 @@ namespace Autofac.Configuration.Test.Core
             }
         }
 
-        public class ConvertibleListConverter : TypeConverter
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class ConvertibleListConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {
@@ -333,7 +339,7 @@ namespace Autofac.Configuration.Test.Core
                     return null;
                 }
 
-                if (!(value is ConfiguredListParameter castValue))
+                if (value is not ConfiguredListParameter castValue)
                 {
                     return base.ConvertFrom(context, culture, value);
                 }
@@ -349,7 +355,8 @@ namespace Autofac.Configuration.Test.Core
             }
         }
 
-        public class HasConvertibleParametersAndProperties
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class HasConvertibleParametersAndProperties
         {
             public HasConvertibleParametersAndProperties([TypeConverter(typeof(ConvertibleConverter))] Convertible parameter)
             {
@@ -362,7 +369,8 @@ namespace Autofac.Configuration.Test.Core
             public Convertible Property { get; set; }
         }
 
-        public class HasDictionaryProperty
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class HasDictionaryProperty
         {
             [TypeConverter(typeof(ConvertibleDictionaryConverter))]
             public IDictionary<string, Convertible> Convertible { get; set; }
@@ -372,7 +380,8 @@ namespace Autofac.Configuration.Test.Core
             public Dictionary<string, double> Populated { get; set; }
         }
 
-        public class HasEnumerableParameter
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class HasEnumerableParameter
         {
             public HasEnumerableParameter(IList<string> list)
             {
@@ -382,7 +391,8 @@ namespace Autofac.Configuration.Test.Core
             public IList<string> List { get; private set; }
         }
 
-        public class HasEnumerableProperty
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class HasEnumerableProperty
         {
             [TypeConverter(typeof(ConvertibleListConverter))]
             public IEnumerable<Convertible> Convertible { get; set; }
@@ -392,7 +402,8 @@ namespace Autofac.Configuration.Test.Core
             public IEnumerable<double> Populated { get; set; }
         }
 
-        public class HasSimpleParametersAndProperties : BaseSimpleParametersAndProperties
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class HasSimpleParametersAndProperties : BaseSimpleParametersAndProperties
         {
             public HasSimpleParametersAndProperties(double number, IPAddress ip)
             {

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_DictionaryParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_DictionaryParametersFixture.cs
@@ -3,155 +3,154 @@
 
 using System.Collections;
 
-namespace Autofac.Configuration.Test.Core
+namespace Autofac.Configuration.Test.Core;
+
+public class ConfigurationExtensions_DictionaryParametersFixture
 {
-    public class ConfigurationExtensions_DictionaryParametersFixture
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class A
     {
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class A
+        public IDictionary<string, string> Dictionary { get; set; }
+    }
+
+    [Fact]
+    public void InjectsDictionaryProperty()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+
+        var poco = container.Resolve<A>();
+
+        Assert.True(poco.Dictionary.Count == 2);
+        Assert.True(poco.Dictionary.ContainsKey("Key1"));
+        Assert.True(poco.Dictionary.ContainsKey("Key2"));
+        Assert.Equal("Val1", poco.Dictionary["Key1"]);
+        Assert.Equal("Val2", poco.Dictionary["Key2"]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class B
+    {
+        public IDictionary<string, string> Dictionary { get; set; }
+
+        public B(IDictionary<string, string> dictionary)
         {
-            public IDictionary<string, string> Dictionary { get; set; }
+            Dictionary = dictionary;
         }
+    }
 
-        [Fact]
-        public void InjectsDictionaryProperty()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+    [Fact]
+    public void InjectsDictionaryParameter()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
 
-            var poco = container.Resolve<A>();
+        var poco = container.Resolve<B>();
 
-            Assert.True(poco.Dictionary.Count == 2);
-            Assert.True(poco.Dictionary.ContainsKey("Key1"));
-            Assert.True(poco.Dictionary.ContainsKey("Key2"));
-            Assert.Equal("Val1", poco.Dictionary["Key1"]);
-            Assert.Equal("Val2", poco.Dictionary["Key2"]);
-        }
+        Assert.True(poco.Dictionary.Count == 2);
+        Assert.True(poco.Dictionary.ContainsKey("Key1"));
+        Assert.True(poco.Dictionary.ContainsKey("Key2"));
+        Assert.Equal("Val1", poco.Dictionary["Key1"]);
+        Assert.Equal("Val2", poco.Dictionary["Key2"]);
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class B
-        {
-            public IDictionary<string, string> Dictionary { get; set; }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class C
+    {
+        public IDictionary Dictionary { get; set; }
+    }
 
-            public B(IDictionary<string, string> dictionary)
-            {
-                Dictionary = dictionary;
-            }
-        }
+    [Fact]
+    public void InjectsNonGenericDictionary()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
 
-        [Fact]
-        public void InjectsDictionaryParameter()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+        var poco = container.Resolve<C>();
 
-            var poco = container.Resolve<B>();
+        Assert.True(poco.Dictionary.Count == 2);
+        Assert.True(poco.Dictionary.Contains("Key1"));
+        Assert.True(poco.Dictionary.Contains("Key2"));
+        Assert.Equal("Val1", poco.Dictionary["Key1"]);
+        Assert.Equal("Val2", poco.Dictionary["Key2"]);
+    }
 
-            Assert.True(poco.Dictionary.Count == 2);
-            Assert.True(poco.Dictionary.ContainsKey("Key1"));
-            Assert.True(poco.Dictionary.ContainsKey("Key2"));
-            Assert.Equal("Val1", poco.Dictionary["Key1"]);
-            Assert.Equal("Val2", poco.Dictionary["Key2"]);
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class D
+    {
+        public Dictionary<string, string> Dictionary { get; set; }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class C
-        {
-            public IDictionary Dictionary { get; set; }
-        }
+    [Fact]
+    public void InjectsConcreteDictionary()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
 
-        [Fact]
-        public void InjectsNonGenericDictionary()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+        var poco = container.Resolve<D>();
 
-            var poco = container.Resolve<C>();
+        Assert.True(poco.Dictionary.Count == 2);
+        Assert.True(poco.Dictionary.ContainsKey("Key1"));
+        Assert.True(poco.Dictionary.ContainsKey("Key2"));
+        Assert.Equal("Val1", poco.Dictionary["Key1"]);
+        Assert.Equal("Val2", poco.Dictionary["Key2"]);
+    }
 
-            Assert.True(poco.Dictionary.Count == 2);
-            Assert.True(poco.Dictionary.Contains("Key1"));
-            Assert.True(poco.Dictionary.Contains("Key2"));
-            Assert.Equal("Val1", poco.Dictionary["Key1"]);
-            Assert.Equal("Val2", poco.Dictionary["Key2"]);
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class E
+    {
+        public IDictionary<int, string> Dictionary { get; set; }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class D
-        {
-            public Dictionary<string, string> Dictionary { get; set; }
-        }
+    [Fact]
+    public void NumericKeysZeroBasedListConvertedToDictionary()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
 
-        [Fact]
-        public void InjectsConcreteDictionary()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+        var poco = container.Resolve<E>();
 
-            var poco = container.Resolve<D>();
+        Assert.True(poco.Dictionary.Count == 2);
+        Assert.True(poco.Dictionary.ContainsKey(0));
+        Assert.True(poco.Dictionary.ContainsKey(1));
+        Assert.Equal("Val1", poco.Dictionary[0]);
+        Assert.Equal("Val2", poco.Dictionary[1]);
+    }
 
-            Assert.True(poco.Dictionary.Count == 2);
-            Assert.True(poco.Dictionary.ContainsKey("Key1"));
-            Assert.True(poco.Dictionary.ContainsKey("Key2"));
-            Assert.Equal("Val1", poco.Dictionary["Key1"]);
-            Assert.Equal("Val2", poco.Dictionary["Key2"]);
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class F
+    {
+        public IDictionary<string, int> Dictionary { get; set; }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class E
-        {
-            public IDictionary<int, string> Dictionary { get; set; }
-        }
+    [Fact]
+    public void ConvertsDictionaryValue()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
 
-        [Fact]
-        public void NumericKeysZeroBasedListConvertedToDictionary()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+        var poco = container.Resolve<F>();
 
-            var poco = container.Resolve<E>();
+        Assert.True(poco.Dictionary.Count == 2);
+        Assert.True(poco.Dictionary.ContainsKey("Key1"));
+        Assert.True(poco.Dictionary.ContainsKey("Key2"));
+        Assert.Equal(1, poco.Dictionary["Key1"]);
+        Assert.Equal(2, poco.Dictionary["Key2"]);
+    }
 
-            Assert.True(poco.Dictionary.Count == 2);
-            Assert.True(poco.Dictionary.ContainsKey(0));
-            Assert.True(poco.Dictionary.ContainsKey(1));
-            Assert.Equal("Val1", poco.Dictionary[0]);
-            Assert.Equal("Val2", poco.Dictionary[1]);
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class G
+    {
+        public IDictionary<int, string> Dictionary { get; set; }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class F
-        {
-            public IDictionary<string, int> Dictionary { get; set; }
-        }
+    [Fact]
+    public void NumericKeysZeroBasedNonSequential()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
 
-        [Fact]
-        public void ConvertsDictionaryValue()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
+        var poco = container.Resolve<G>();
 
-            var poco = container.Resolve<F>();
-
-            Assert.True(poco.Dictionary.Count == 2);
-            Assert.True(poco.Dictionary.ContainsKey("Key1"));
-            Assert.True(poco.Dictionary.ContainsKey("Key2"));
-            Assert.Equal(1, poco.Dictionary["Key1"]);
-            Assert.Equal(2, poco.Dictionary["Key2"]);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class G
-        {
-            public IDictionary<int, string> Dictionary { get; set; }
-        }
-
-        [Fact]
-        public void NumericKeysZeroBasedNonSequential()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_DictionaryParameters.xml").Build();
-
-            var poco = container.Resolve<G>();
-
-            Assert.True(poco.Dictionary.Count == 3);
-            Assert.True(poco.Dictionary.ContainsKey(0));
-            Assert.True(poco.Dictionary.ContainsKey(5));
-            Assert.True(poco.Dictionary.ContainsKey(10));
-            Assert.Equal("Val0", poco.Dictionary[0]);
-            Assert.Equal("Val1", poco.Dictionary[5]);
-            Assert.Equal("Val2", poco.Dictionary[10]);
-        }
+        Assert.True(poco.Dictionary.Count == 3);
+        Assert.True(poco.Dictionary.ContainsKey(0));
+        Assert.True(poco.Dictionary.ContainsKey(5));
+        Assert.True(poco.Dictionary.ContainsKey(10));
+        Assert.Equal("Val0", poco.Dictionary[0]);
+        Assert.Equal("Val1", poco.Dictionary[5]);
+        Assert.Equal("Val2", poco.Dictionary[10]);
     }
 }

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_DictionaryParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_DictionaryParametersFixture.cs
@@ -9,7 +9,8 @@ namespace Autofac.Configuration.Test.Core
 {
     public class ConfigurationExtensions_DictionaryParametersFixture
     {
-        public class A
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class A
         {
             public IDictionary<string, string> Dictionary { get; set; }
         }
@@ -28,7 +29,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.Dictionary["Key2"]);
         }
 
-        public class B
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class B
         {
             public IDictionary<string, string> Dictionary { get; set; }
 
@@ -52,7 +54,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.Dictionary["Key2"]);
         }
 
-        public class C
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class C
         {
             public IDictionary Dictionary { get; set; }
         }
@@ -71,7 +74,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.Dictionary["Key2"]);
         }
 
-        public class D
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class D
         {
             public Dictionary<string, string> Dictionary { get; set; }
         }
@@ -90,7 +94,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.Dictionary["Key2"]);
         }
 
-        public class E
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class E
         {
             public IDictionary<int, string> Dictionary { get; set; }
         }
@@ -109,7 +114,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.Dictionary[1]);
         }
 
-        public class F
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class F
         {
             public IDictionary<string, int> Dictionary { get; set; }
         }
@@ -128,7 +134,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal(2, poco.Dictionary["Key2"]);
         }
 
-        public class G
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class G
         {
             public IDictionary<int, string> Dictionary { get; set; }
         }

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_DictionaryParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_DictionaryParametersFixture.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections;
-using System.Collections.Generic;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Core
 {

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Core
 {

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
@@ -11,7 +11,8 @@ namespace Autofac.Configuration.Test.Core
 {
     public class ConfigurationExtensions_EnumerableParametersFixture
     {
-        public class A
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class A
         {
             public IList<string> List { get; set; }
         }
@@ -28,7 +29,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.List[1]);
         }
 
-        public class B
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class B
         {
             public IList<double> List { get; set; }
         }
@@ -45,7 +47,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal(2.345, poco.List[1]);
         }
 
-        public class C
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class C
         {
             public IList List { get; set; }
         }
@@ -62,7 +65,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("2.345", poco.List[1]);
         }
 
-        public class D
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class D
         {
             public double Num { get; set; }
         }
@@ -77,7 +81,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal(123.456, poco.Num);
         }
 
-        public class E
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class E
         {
             public IList<double> List { get; set; }
 
@@ -119,7 +124,8 @@ namespace Autofac.Configuration.Test.Core
                 });
         }
 
-        public class G
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class G
         {
             public IEnumerable Enumerable { get; set; }
         }
@@ -138,7 +144,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", enumerable[1]);
         }
 
-        public class H
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class H
         {
             public IEnumerable<double> Enumerable { get; set; }
         }
@@ -157,7 +164,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal(2.345, enumerable[1]);
         }
 
-        public class I
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class I
         {
             public ICollection<double> Collection { get; set; }
         }
@@ -175,7 +183,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal(2.345, poco.Collection.Last());
         }
 
-        public class J
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class J
         {
             public J(IList<string> list)
             {
@@ -197,7 +206,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.List[1]);
         }
 
-        public class K
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class K
         {
             public K(IList<string> list = null)
             {
@@ -219,7 +229,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.List[1]);
         }
 
-        public class L
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class L
         {
             public L()
             {
@@ -246,7 +257,8 @@ namespace Autofac.Configuration.Test.Core
             Assert.Equal("Val2", poco.List[1]);
         }
 
-        public class M
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class M
         {
             public M(IList<string> list) => List = list;
 

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
@@ -4,285 +4,284 @@
 using System.Collections;
 using System.Globalization;
 
-namespace Autofac.Configuration.Test.Core
+namespace Autofac.Configuration.Test.Core;
+
+public class ConfigurationExtensions_EnumerableParametersFixture
 {
-    public class ConfigurationExtensions_EnumerableParametersFixture
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class A
     {
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class A
+        public IList<string> List { get; set; }
+    }
+
+    [Fact]
+    public void PropertyStringListInjection()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<A>();
+
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal("Val1", poco.List[0]);
+        Assert.Equal("Val2", poco.List[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class B
+    {
+        public IList<double> List { get; set; }
+    }
+
+    [Fact]
+    public void ConvertsTypeInList()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<B>();
+
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal(1.234, poco.List[0]);
+        Assert.Equal(2.345, poco.List[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class C
+    {
+        public IList List { get; set; }
+    }
+
+    [Fact]
+    public void FillsNonGenericListWithString()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<C>();
+
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal("1.234", poco.List[0]);
+        Assert.Equal("2.345", poco.List[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class D
+    {
+        public double Num { get; set; }
+    }
+
+    [Fact]
+    public void InjectsSingleValueWithConversion()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<D>();
+
+        Assert.Equal(123.456, poco.Num);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class E
+    {
+        public IList<double> List { get; set; }
+
+        public E(IList<double> list)
         {
-            public IList<string> List { get; set; }
+            List = list;
         }
+    }
 
-        [Fact]
-        public void PropertyStringListInjection()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+    [Fact]
+    public void InjectsConstructorParameter()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
 
-            var poco = container.Resolve<A>();
+        var poco = container.Resolve<E>();
 
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal("Val1", poco.List[0]);
-            Assert.Equal("Val2", poco.List[1]);
-        }
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal(1.234, poco.List[0]);
+        Assert.Equal(2.345, poco.List[1]);
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class B
-        {
-            public IList<double> List { get; set; }
-        }
-
-        [Fact]
-        public void ConvertsTypeInList()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<B>();
-
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal(1.234, poco.List[0]);
-            Assert.Equal(2.345, poco.List[1]);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class C
-        {
-            public IList List { get; set; }
-        }
-
-        [Fact]
-        public void FillsNonGenericListWithString()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<C>();
-
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal("1.234", poco.List[0]);
-            Assert.Equal("2.345", poco.List[1]);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class D
-        {
-            public double Num { get; set; }
-        }
-
-        [Fact]
-        public void InjectsSingleValueWithConversion()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<D>();
-
-            Assert.Equal(123.456, poco.Num);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class E
-        {
-            public IList<double> List { get; set; }
-
-            public E(IList<double> list)
+    [Theory]
+    [MemberData(nameof(ParsingCultures))]
+    public void TypeConversionsAreCaseInvariant(CultureInfo culture)
+    {
+        // Issue #26 - parsing needs to be InvariantCulture or config fails
+        // when it's moved from machine to machine.
+        TestCulture.With(
+            culture,
+            () =>
             {
-                List = list;
-            }
-        }
+                var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
 
-        [Fact]
-        public void InjectsConstructorParameter()
+                var poco = container.Resolve<E>();
+
+                Assert.True(poco.List.Count == 2);
+                Assert.Equal(1.234, poco.List[0]);
+                Assert.Equal(2.345, poco.List[1]);
+            });
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class G
+    {
+        public IEnumerable Enumerable { get; set; }
+    }
+
+    [Fact]
+    public void InjectsIEnumerable()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<G>();
+
+        Assert.NotNull(poco.Enumerable);
+        var enumerable = poco.Enumerable.Cast<string>().ToList();
+        Assert.True(enumerable.Count == 2);
+        Assert.Equal("Val1", enumerable[0]);
+        Assert.Equal("Val2", enumerable[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class H
+    {
+        public IEnumerable<double> Enumerable { get; set; }
+    }
+
+    [Fact]
+    public void InjectsGenericIEnumerable()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<H>();
+
+        Assert.NotNull(poco.Enumerable);
+        var enumerable = poco.Enumerable.ToList();
+        Assert.True(enumerable.Count == 2);
+        Assert.Equal(1.234, enumerable[0]);
+        Assert.Equal(2.345, enumerable[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class I
+    {
+        public ICollection<double> Collection { get; set; }
+    }
+
+    [Fact]
+    public void InjectsGenericCollection()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<I>();
+
+        Assert.NotNull(poco.Collection);
+        Assert.True(poco.Collection.Count == 2);
+        Assert.Equal(1.234, poco.Collection.First());
+        Assert.Equal(2.345, poco.Collection.Last());
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class J
+    {
+        public J(IList<string> list)
         {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<E>();
-
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal(1.234, poco.List[0]);
-            Assert.Equal(2.345, poco.List[1]);
+            List = list;
         }
 
-        [Theory]
-        [MemberData(nameof(ParsingCultures))]
-        public void TypeConversionsAreCaseInvariant(CultureInfo culture)
+        public IList<string> List { get; private set; }
+    }
+
+    [Fact]
+    public void ParameterStringListInjection()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<J>();
+
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal("Val1", poco.List[0]);
+        Assert.Equal("Val2", poco.List[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class K
+    {
+        public K(IList<string> list = null)
         {
-            // Issue #26 - parsing needs to be InvariantCulture or config fails
-            // when it's moved from machine to machine.
-            TestCulture.With(
-                culture,
-                () =>
-                {
-                    var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-                    var poco = container.Resolve<E>();
-
-                    Assert.True(poco.List.Count == 2);
-                    Assert.Equal(1.234, poco.List[0]);
-                    Assert.Equal(2.345, poco.List[1]);
-                });
+            List = list;
         }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class G
+        public IList<string> List { get; private set; }
+    }
+
+    [Fact]
+    public void ParameterStringListInjectionOptionalParameter()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+
+        var poco = container.Resolve<K>();
+
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal("Val1", poco.List[0]);
+        Assert.Equal("Val2", poco.List[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class L
+    {
+        public L()
         {
-            public IEnumerable Enumerable { get; set; }
+            List = new List<string>();
         }
 
-        [Fact]
-        public void InjectsIEnumerable()
+        public L(IList<string> list = null)
         {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<G>();
-
-            Assert.NotNull(poco.Enumerable);
-            var enumerable = poco.Enumerable.Cast<string>().ToList();
-            Assert.True(enumerable.Count == 2);
-            Assert.Equal("Val1", enumerable[0]);
-            Assert.Equal("Val2", enumerable[1]);
+            List = list;
         }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class H
-        {
-            public IEnumerable<double> Enumerable { get; set; }
-        }
+        public IList<string> List { get; private set; }
+    }
 
-        [Fact]
-        public void InjectsGenericIEnumerable()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+    [Fact]
+    public void ParameterStringListInjectionMultipleConstructors()
+    {
+        var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
 
-            var poco = container.Resolve<H>();
+        var poco = container.Resolve<L>();
 
-            Assert.NotNull(poco.Enumerable);
-            var enumerable = poco.Enumerable.ToList();
-            Assert.True(enumerable.Count == 2);
-            Assert.Equal(1.234, enumerable[0]);
-            Assert.Equal(2.345, enumerable[1]);
-        }
+        Assert.True(poco.List.Count == 2);
+        Assert.Equal("Val1", poco.List[0]);
+        Assert.Equal("Val2", poco.List[1]);
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class I
-        {
-            public ICollection<double> Collection { get; set; }
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class M
+    {
+        public M(IList<string> list) => List = list;
 
-        [Fact]
-        public void InjectsGenericCollection()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
+        public IList<string> List { get; }
+    }
 
-            var poco = container.Resolve<I>();
+    /// <summary>
+    /// A characterization test, not intended to express desired behavior, but to capture the current behavior.
+    /// </summary>
+    [Fact]
+    public void ParameterStringListInjectionSecondElementHasNoName()
+    {
+        var container = EmbeddedConfiguration
+            .ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
 
-            Assert.NotNull(poco.Collection);
-            Assert.True(poco.Collection.Count == 2);
-            Assert.Equal(1.234, poco.Collection.First());
-            Assert.Equal(2.345, poco.Collection.Last());
-        }
+        var poco = container.Resolve<M>();
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class J
-        {
-            public J(IList<string> list)
-            {
-                List = list;
-            }
+        // Val2 is dropped from the configuration when it's parsed.
+        Assert.Collection(poco.List, v => Assert.Equal("Val1", v));
+    }
 
-            public IList<string> List { get; private set; }
-        }
-
-        [Fact]
-        public void ParameterStringListInjection()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<J>();
-
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal("Val1", poco.List[0]);
-            Assert.Equal("Val2", poco.List[1]);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class K
-        {
-            public K(IList<string> list = null)
-            {
-                List = list;
-            }
-
-            public IList<string> List { get; private set; }
-        }
-
-        [Fact]
-        public void ParameterStringListInjectionOptionalParameter()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<K>();
-
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal("Val1", poco.List[0]);
-            Assert.Equal("Val2", poco.List[1]);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class L
-        {
-            public L()
-            {
-                List = new List<string>();
-            }
-
-            public L(IList<string> list = null)
-            {
-                List = list;
-            }
-
-            public IList<string> List { get; private set; }
-        }
-
-        [Fact]
-        public void ParameterStringListInjectionMultipleConstructors()
-        {
-            var container = EmbeddedConfiguration.ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<L>();
-
-            Assert.True(poco.List.Count == 2);
-            Assert.Equal("Val1", poco.List[0]);
-            Assert.Equal("Val2", poco.List[1]);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class M
-        {
-            public M(IList<string> list) => List = list;
-
-            public IList<string> List { get; }
-        }
-
-        /// <summary>
-        /// A characterization test, not intended to express desired behaviour, but to capture the current behaviour.
-        /// </summary>
-        [Fact]
-        public void ParameterStringListInjectionSecondElementHasNoName()
-        {
-            var container = EmbeddedConfiguration
-                .ConfigureContainerWithXml("ConfigurationExtensions_EnumerableParameters.xml").Build();
-
-            var poco = container.Resolve<M>();
-
-            // Val2 is dropped from the configuration when it's parsed.
-            Assert.Collection(poco.List, v => Assert.Equal("Val1", v));
-        }
-
-        public static IEnumerable<object[]> ParsingCultures()
-        {
-            yield return new object[] { new CultureInfo("en-US") };
-            yield return new object[] { new CultureInfo("es-MX") };
-            yield return new object[] { new CultureInfo("it-IT") };
-            yield return new object[] { CultureInfo.InvariantCulture };
-        }
+    public static IEnumerable<object[]> ParsingCultures()
+    {
+        yield return new object[] { new CultureInfo("en-US") };
+        yield return new object[] { new CultureInfo("es-MX") };
+        yield return new object[] { new CultureInfo("it-IT") };
+        yield return new object[] { CultureInfo.InvariantCulture };
     }
 }

--- a/test/Autofac.Configuration.Test/Core/ConfigurationRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationRegistrarFixture.cs
@@ -4,24 +4,23 @@
 using Autofac.Configuration.Core;
 using Microsoft.Extensions.Configuration;
 
-namespace Autofac.Configuration.Test.Core
-{
-    public class ConfigurationRegistrarFixture
-    {
-        [Fact]
-        public void RegisterConfiguration_NullBuilder()
-        {
-            var configuration = new Mock<IConfiguration>();
-            var registrar = new ConfigurationRegistrar();
-            Assert.Throws<ArgumentNullException>(() => registrar.RegisterConfiguration(null, configuration.Object));
-        }
+namespace Autofac.Configuration.Test.Core;
 
-        [Fact]
-        public void RegisterConfiguration_NullConfiguration()
-        {
-            var builder = new ContainerBuilder();
-            var registrar = new ConfigurationRegistrar();
-            Assert.Throws<ArgumentNullException>(() => registrar.RegisterConfiguration(builder, null));
-        }
+public class ConfigurationRegistrarFixture
+{
+    [Fact]
+    public void RegisterConfiguration_NullBuilder()
+    {
+        var configuration = new Mock<IConfiguration>();
+        var registrar = new ConfigurationRegistrar();
+        Assert.Throws<ArgumentNullException>(() => registrar.RegisterConfiguration(null, configuration.Object));
+    }
+
+    [Fact]
+    public void RegisterConfiguration_NullConfiguration()
+    {
+        var builder = new ContainerBuilder();
+        var registrar = new ConfigurationRegistrar();
+        Assert.Throws<ArgumentNullException>(() => registrar.RegisterConfiguration(builder, null));
     }
 }

--- a/test/Autofac.Configuration.Test/Core/ConfigurationRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationRegistrarFixture.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Configuration.Core;
 using Microsoft.Extensions.Configuration;
-using Moq;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Core
 {

--- a/test/Autofac.Configuration.Test/Core/ModuleConfiguration_ComplexTypeFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ModuleConfiguration_ComplexTypeFixture.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Xunit;
-
 namespace Autofac.Configuration.Test.Core
 {
     public class ModuleConfiguration_ComplexTypeFixture

--- a/test/Autofac.Configuration.Test/Core/ModuleConfiguration_ComplexTypeFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ModuleConfiguration_ComplexTypeFixture.cs
@@ -18,7 +18,7 @@ namespace Autofac.Configuration.Test.Core
 
             var poco = container.Resolve<ComplexParameterComponent>();
 
-            Assert.Equal(2, poco.List.Count());
+            Assert.Equal(2, poco.List.Count);
             Assert.Equal("Val1", poco.List[0]);
             Assert.Equal("Val2", poco.List[1]);
         }
@@ -31,11 +31,12 @@ namespace Autofac.Configuration.Test.Core
 
             var poco = container.Resolve<ComplexPropertyComponent>();
 
-            Assert.Equal(2, poco.List.Count());
+            Assert.Equal(2, poco.List.Count);
             Assert.Equal("Val3", poco.List[0]);
             Assert.Equal("Val4", poco.List[1]);
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ComplexParameterTypeModule : Module
         {
             public ComplexType ComplexType { get; set; }
@@ -51,6 +52,7 @@ namespace Autofac.Configuration.Test.Core
             }
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ComplexPropertyTypeModule : Module
         {
             public ComplexType ComplexType { get; set; }
@@ -61,16 +63,19 @@ namespace Autofac.Configuration.Test.Core
             }
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ComplexType
         {
             public IList<string> List { get; set; }
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ComplexParameterComponent
         {
             public IList<string> List { get; set; }
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ComplexPropertyComponent
         {
             public IList<string> List { get; set; }

--- a/test/Autofac.Configuration.Test/Core/ModuleConfiguration_ComplexTypeFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ModuleConfiguration_ComplexTypeFixture.cs
@@ -1,79 +1,78 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Configuration.Test.Core
+namespace Autofac.Configuration.Test.Core;
+
+public class ModuleConfiguration_ComplexTypeFixture
 {
-    public class ModuleConfiguration_ComplexTypeFixture
+    [Fact]
+    public void RegisterConfiguredModules_ComplexParameterType()
     {
-        [Fact]
-        public void RegisterConfiguredModules_ComplexParameterType()
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleConfiguration_ComplexType.json");
+        var container = builder.Build();
+
+        var poco = container.Resolve<ComplexParameterComponent>();
+
+        Assert.Equal(2, poco.List.Count);
+        Assert.Equal("Val1", poco.List[0]);
+        Assert.Equal("Val2", poco.List[1]);
+    }
+
+    [Fact]
+    public void RegisterConfiguredModules_ComplexPropertyType()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleConfiguration_ComplexType.json");
+        var container = builder.Build();
+
+        var poco = container.Resolve<ComplexPropertyComponent>();
+
+        Assert.Equal(2, poco.List.Count);
+        Assert.Equal("Val3", poco.List[0]);
+        Assert.Equal("Val4", poco.List[1]);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ComplexParameterTypeModule : Module
+    {
+        public ComplexType ComplexType { get; set; }
+
+        public ComplexParameterTypeModule(ComplexType complexType)
         {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleConfiguration_ComplexType.json");
-            var container = builder.Build();
-
-            var poco = container.Resolve<ComplexParameterComponent>();
-
-            Assert.Equal(2, poco.List.Count);
-            Assert.Equal("Val1", poco.List[0]);
-            Assert.Equal("Val2", poco.List[1]);
+            ComplexType = complexType;
         }
 
-        [Fact]
-        public void RegisterConfiguredModules_ComplexPropertyType()
+        protected override void Load(ContainerBuilder builder)
         {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleConfiguration_ComplexType.json");
-            var container = builder.Build();
-
-            var poco = container.Resolve<ComplexPropertyComponent>();
-
-            Assert.Equal(2, poco.List.Count);
-            Assert.Equal("Val3", poco.List[0]);
-            Assert.Equal("Val4", poco.List[1]);
+            builder.RegisterType<ComplexParameterComponent>().WithProperty("List", ComplexType.List);
         }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ComplexParameterTypeModule : Module
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ComplexPropertyTypeModule : Module
+    {
+        public ComplexType ComplexType { get; set; }
+
+        protected override void Load(ContainerBuilder builder)
         {
-            public ComplexType ComplexType { get; set; }
-
-            public ComplexParameterTypeModule(ComplexType complexType)
-            {
-                ComplexType = complexType;
-            }
-
-            protected override void Load(ContainerBuilder builder)
-            {
-                builder.RegisterType<ComplexParameterComponent>().WithProperty("List", ComplexType.List);
-            }
+            builder.RegisterType<ComplexPropertyComponent>().WithProperty("List", ComplexType.List);
         }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ComplexPropertyTypeModule : Module
-        {
-            public ComplexType ComplexType { get; set; }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ComplexType
+    {
+        public IList<string> List { get; set; }
+    }
 
-            protected override void Load(ContainerBuilder builder)
-            {
-                builder.RegisterType<ComplexPropertyComponent>().WithProperty("List", ComplexType.List);
-            }
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ComplexParameterComponent
+    {
+        public IList<string> List { get; set; }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ComplexType
-        {
-            public IList<string> List { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ComplexParameterComponent
-        {
-            public IList<string> List { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ComplexPropertyComponent
-        {
-            public IList<string> List { get; set; }
-        }
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ComplexPropertyComponent
+    {
+        public IList<string> List { get; set; }
     }
 }

--- a/test/Autofac.Configuration.Test/Core/ModuleRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ModuleRegistrarFixture.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Autofac.Core.Activators.Reflection;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Core
 {

--- a/test/Autofac.Configuration.Test/Core/ModuleRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ModuleRegistrarFixture.cs
@@ -40,6 +40,7 @@ namespace Autofac.Configuration.Test.Core
             Assert.Throws<NoConstructorsFoundException>(() => builder.Build());
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ParameterizedModule : Module
         {
             public ParameterizedModule(string message)
@@ -51,10 +52,11 @@ namespace Autofac.Configuration.Test.Core
 
             protected override void Load(ContainerBuilder builder)
             {
-                builder.RegisterType<SimpleComponent>().WithProperty("Message", Message);
+                builder.RegisterType<SimpleComponent>().WithProperty(nameof(Message), Message);
             }
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class ProtectedModule : Module
         {
             protected ProtectedModule(string message)
@@ -69,6 +71,7 @@ namespace Autofac.Configuration.Test.Core
         {
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class SimpleComponent : ITestComponent
         {
             public SimpleComponent()

--- a/test/Autofac.Configuration.Test/Core/ModuleRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ModuleRegistrarFixture.cs
@@ -3,87 +3,86 @@
 
 using Autofac.Core.Activators.Reflection;
 
-namespace Autofac.Configuration.Test.Core
+namespace Autofac.Configuration.Test.Core;
+
+public class ModuleRegistrarFixture
 {
-    public class ModuleRegistrarFixture
+    [Fact]
+    public void RegisterConfiguredModules_AllowsMultipleModulesOfSameTypeWithDifferentParameters()
     {
-        [Fact]
-        public void RegisterConfiguredModules_AllowsMultipleModulesOfSameTypeWithDifferentParameters()
-        {
-            // Issue #271: Could not register more than one module with the same type but different parameters in XmlConfiguration.
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleRegistrar_SameModuleRegisteredMultipleTimes.json");
-            var container = builder.Build();
-            var collection = container.Resolve<IEnumerable<SimpleComponent>>();
-            Assert.Equal(2, collection.Count());
+        // Issue #271: Could not register more than one module with the same type but different parameters in XmlConfiguration.
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleRegistrar_SameModuleRegisteredMultipleTimes.json");
+        var container = builder.Build();
+        var collection = container.Resolve<IEnumerable<SimpleComponent>>();
+        Assert.Equal(2, collection.Count());
 
-            // Test using Any() because we aren't necessarily guaranteed the order of resolution.
-            Assert.True(collection.Any(a => a.Message == "First"), "The first registration wasn't found.");
-            Assert.True(collection.Any(a => a.Message == "Second"), "The second registration wasn't found.");
+        // Test using Any() because we aren't necessarily guaranteed the order of resolution.
+        Assert.True(collection.Any(a => a.Message == "First"), "The first registration wasn't found.");
+        Assert.True(collection.Any(a => a.Message == "Second"), "The second registration wasn't found.");
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_MetadataMissingName_ThrowsInvalidOperation()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ModuleRegistrar_ModulesMissingName.xml");
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        Assert.Equal("The 'modules' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'modules' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
+    }
+
+    [Fact]
+    public void RegisterConfiguredComponents_ModuleWithNoPublicConstructor_ThrowsInvalidOperation()
+    {
+        var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleRegistrar_ModuleWithNoPublicConstructor.json");
+        Assert.Throws<NoConstructorsFoundException>(() => builder.Build());
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ParameterizedModule : Module
+    {
+        public ParameterizedModule(string message)
+        {
+            Message = message;
         }
 
-        [Fact]
-        public void RegisterConfiguredComponents_MetadataMissingName_ThrowsInvalidOperation()
+        public string Message { get; private set; }
+
+        protected override void Load(ContainerBuilder builder)
         {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithXml("ModuleRegistrar_ModulesMissingName.xml");
-            var exception = Assert.Throws<InvalidOperationException>(() => builder.Build());
-            Assert.Equal("The 'modules' collection should be ordinal (like an array) with items that have numeric names to indicate the index in the collection. 'modules' didn't have a numeric name so couldn't be parsed. Check https://autofac.readthedocs.io/en/latest/configuration/xml.html for configuration examples.", exception.Message);
+            builder.RegisterType<SimpleComponent>().WithProperty(nameof(Message), Message);
+        }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ProtectedModule : Module
+    {
+        protected ProtectedModule(string message)
+        {
+            Message = message;
         }
 
-        [Fact]
-        public void RegisterConfiguredComponents_ModuleWithNoPublicConstructor_ThrowsInvalidOperation()
-        {
-            var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ModuleRegistrar_ModuleWithNoPublicConstructor.json");
-            Assert.Throws<NoConstructorsFoundException>(() => builder.Build());
-        }
+        public string Message { get; private set; }
+    }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ParameterizedModule : Module
-        {
-            public ParameterizedModule(string message)
-            {
-                Message = message;
-            }
+    private interface ITestComponent
+    {
+    }
 
-            public string Message { get; private set; }
-
-            protected override void Load(ContainerBuilder builder)
-            {
-                builder.RegisterType<SimpleComponent>().WithProperty(nameof(Message), Message);
-            }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ProtectedModule : Module
-        {
-            protected ProtectedModule(string message)
-            {
-                Message = message;
-            }
-
-            public string Message { get; private set; }
-        }
-
-        private interface ITestComponent
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class SimpleComponent : ITestComponent
+    {
+        public SimpleComponent()
         {
         }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class SimpleComponent : ITestComponent
+        public SimpleComponent(double input)
         {
-            public SimpleComponent()
-            {
-            }
-
-            public SimpleComponent(double input)
-            {
-                Input = input;
-            }
-
-            public bool ABool { get; set; }
-
-            public double Input { get; set; }
-
-            public string Message { get; set; }
+            Input = input;
         }
+
+        public bool ABool { get; set; }
+
+        public double Input { get; set; }
+
+        public string Message { get; set; }
     }
 }

--- a/test/Autofac.Configuration.Test/EmbeddedConfiguration.cs
+++ b/test/Autofac.Configuration.Test/EmbeddedConfiguration.cs
@@ -6,50 +6,49 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.Configuration.Xml;
 
-namespace Autofac.Configuration.Test
+namespace Autofac.Configuration.Test;
+
+public static class EmbeddedConfiguration
 {
-    public static class EmbeddedConfiguration
+    public static ContainerBuilder ConfigureContainer(IConfiguration configuration)
     {
-        public static ContainerBuilder ConfigureContainer(IConfiguration configuration)
-        {
-            var builder = new ContainerBuilder();
-            builder.RegisterModule(new ConfigurationModule(configuration));
-            return builder;
-        }
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(new ConfigurationModule(configuration));
+        return builder;
+    }
 
-        public static ContainerBuilder ConfigureContainerWithJson(string configFile)
-        {
-            return ConfigureContainer(LoadJson(configFile));
-        }
+    public static ContainerBuilder ConfigureContainerWithJson(string configFile)
+    {
+        return ConfigureContainer(LoadJson(configFile));
+    }
 
-        public static ContainerBuilder ConfigureContainerWithXml(string configFile)
-        {
-            return ConfigureContainer(LoadXml(configFile));
-        }
+    public static ContainerBuilder ConfigureContainerWithXml(string configFile)
+    {
+        return ConfigureContainer(LoadXml(configFile));
+    }
 
-        public static IConfiguration LoadJson(string configFile)
+    public static IConfiguration LoadJson(string configFile)
+    {
+        using (var stream = GetEmbeddedFileStream(configFile))
         {
-            using (var stream = GetEmbeddedFileStream(configFile))
-            {
-                var provider = new EmbeddedConfigurationProvider<JsonConfigurationSource>(stream);
-                var config = new ConfigurationRoot(new List<IConfigurationProvider> { provider });
-                return config;
-            }
+            var provider = new EmbeddedConfigurationProvider<JsonConfigurationSource>(stream);
+            var config = new ConfigurationRoot(new List<IConfigurationProvider> { provider });
+            return config;
         }
+    }
 
-        public static IConfiguration LoadXml(string configFile)
+    public static IConfiguration LoadXml(string configFile)
+    {
+        using (var stream = GetEmbeddedFileStream(configFile))
         {
-            using (var stream = GetEmbeddedFileStream(configFile))
-            {
-                var provider = new EmbeddedConfigurationProvider<XmlConfigurationSource>(stream);
-                var config = new ConfigurationRoot(new List<IConfigurationProvider> { provider });
-                return config;
-            }
+            var provider = new EmbeddedConfigurationProvider<XmlConfigurationSource>(stream);
+            var config = new ConfigurationRoot(new List<IConfigurationProvider> { provider });
+            return config;
         }
+    }
 
-        private static Stream GetEmbeddedFileStream(string configFile)
-        {
-            return typeof(EmbeddedConfiguration).GetTypeInfo().Assembly.GetManifestResourceStream("Autofac.Configuration.Test.Files." + configFile);
-        }
+    private static Stream GetEmbeddedFileStream(string configFile)
+    {
+        return typeof(EmbeddedConfiguration).GetTypeInfo().Assembly.GetManifestResourceStream("Autofac.Configuration.Test.Files." + configFile);
     }
 }

--- a/test/Autofac.Configuration.Test/EmbeddedConfiguration.cs
+++ b/test/Autofac.Configuration.Test/EmbeddedConfiguration.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
-using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;

--- a/test/Autofac.Configuration.Test/EmbeddedConfigurationProvider.cs
+++ b/test/Autofac.Configuration.Test/EmbeddedConfigurationProvider.cs
@@ -4,50 +4,49 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 
-namespace Autofac.Configuration.Test
+namespace Autofac.Configuration.Test;
+
+/// <summary>
+/// Configuration file proxy provider that skips loading and provides
+/// contents from a stream.
+/// </summary>
+/// <typeparam name="TSource">
+/// The type of configuration source that generates a file provider.
+/// </typeparam>
+public class EmbeddedConfigurationProvider<TSource> : IConfigurationProvider
+    where TSource : IConfigurationSource, new()
 {
-    /// <summary>
-    /// Configuration file proxy provider that skips loading and provides
-    /// contnts from a stream.
-    /// </summary>
-    /// <typeparam name="TSource">
-    /// The type of configuration source that generates a file provider.
-    /// </typeparam>
-    public class EmbeddedConfigurationProvider<TSource> : IConfigurationProvider
-        where TSource : IConfigurationSource, new()
+    private readonly FileConfigurationProvider _provider;
+
+    public EmbeddedConfigurationProvider(Stream fileStream)
     {
-        private readonly FileConfigurationProvider _provider;
+        var source = new TSource();
+        _provider = source.Build(new ConfigurationBuilder()) as FileConfigurationProvider;
+        _provider.Load(fileStream);
+    }
 
-        public EmbeddedConfigurationProvider(Stream fileStream)
-        {
-            var source = new TSource();
-            _provider = source.Build(new ConfigurationBuilder()) as FileConfigurationProvider;
-            _provider.Load(fileStream);
-        }
+    public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath)
+    {
+        return _provider.GetChildKeys(earlierKeys, parentPath);
+    }
 
-        public IEnumerable<string> GetChildKeys(IEnumerable<string> earlierKeys, string parentPath)
-        {
-            return _provider.GetChildKeys(earlierKeys, parentPath);
-        }
+    public IChangeToken GetReloadToken()
+    {
+        return _provider.GetReloadToken();
+    }
 
-        public IChangeToken GetReloadToken()
-        {
-            return _provider.GetReloadToken();
-        }
+    public void Load()
+    {
+        // Do nothing - we load via stream.
+    }
 
-        public void Load()
-        {
-            // Do nothing - we load via stream.
-        }
+    public void Set(string key, string value)
+    {
+        _provider.Set(key, value);
+    }
 
-        public void Set(string key, string value)
-        {
-            _provider.Set(key, value);
-        }
-
-        public bool TryGet(string key, out string value)
-        {
-            return _provider.TryGet(key, out value);
-        }
+    public bool TryGet(string key, out string value)
+    {
+        return _provider.TryGet(key, out value);
     }
 }

--- a/test/Autofac.Configuration.Test/EmbeddedConfigurationProvider.cs
+++ b/test/Autofac.Configuration.Test/EmbeddedConfigurationProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
-using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 

--- a/test/Autofac.Configuration.Test/Properties/AssemblyInfo.cs
+++ b/test/Autofac.Configuration.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+[assembly: ComVisible(false)]
+[assembly: CLSCompliant(false)]

--- a/test/Autofac.Configuration.Test/TestCulture.cs
+++ b/test/Autofac.Configuration.Test/TestCulture.cs
@@ -3,29 +3,28 @@
 
 using System.Globalization;
 
-namespace Autofac.Configuration.Test
+namespace Autofac.Configuration.Test;
+
+public static class TestCulture
 {
-    public static class TestCulture
+    public static void With(CultureInfo culture, Action test)
     {
-        public static void With(CultureInfo culture, Action test)
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+        Thread.CurrentThread.CurrentCulture = culture;
+        Thread.CurrentThread.CurrentUICulture = culture;
+        CultureInfo.CurrentCulture.ClearCachedData();
+        CultureInfo.CurrentUICulture.ClearCachedData();
+        try
         {
-            var originalCulture = Thread.CurrentThread.CurrentCulture;
-            var originalUICulture = Thread.CurrentThread.CurrentUICulture;
-            Thread.CurrentThread.CurrentCulture = culture;
-            Thread.CurrentThread.CurrentUICulture = culture;
+            test?.Invoke();
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
             CultureInfo.CurrentCulture.ClearCachedData();
             CultureInfo.CurrentUICulture.ClearCachedData();
-            try
-            {
-                test?.Invoke();
-            }
-            finally
-            {
-                Thread.CurrentThread.CurrentCulture = originalCulture;
-                Thread.CurrentThread.CurrentUICulture = originalUICulture;
-                CultureInfo.CurrentCulture.ClearCachedData();
-                CultureInfo.CurrentUICulture.ClearCachedData();
-            }
         }
     }
 }

--- a/test/Autofac.Configuration.Test/TestCulture.cs
+++ b/test/Autofac.Configuration.Test/TestCulture.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.Globalization;
-using System.Threading;
 
 namespace Autofac.Configuration.Test
 {

--- a/test/Autofac.Configuration.Test/TestCulture.cs
+++ b/test/Autofac.Configuration.Test/TestCulture.cs
@@ -19,7 +19,7 @@ namespace Autofac.Configuration.Test
             CultureInfo.CurrentUICulture.ClearCachedData();
             try
             {
-                test();
+                test?.Invoke();
             }
             finally
             {

--- a/test/Autofac.Configuration.Test/Util/ReflectionExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/ReflectionExtensionsFixture.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using Autofac.Configuration.Util;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Util
 {

--- a/test/Autofac.Configuration.Test/Util/ReflectionExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/ReflectionExtensionsFixture.cs
@@ -27,6 +27,7 @@ namespace Autofac.Configuration.Test.Util
             Assert.Null(actual);
         }
 
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
         private class HasProperty
         {
             public string NotSetter(string value)

--- a/test/Autofac.Configuration.Test/Util/ReflectionExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/ReflectionExtensionsFixture.cs
@@ -4,37 +4,36 @@
 using System.Reflection;
 using Autofac.Configuration.Util;
 
-namespace Autofac.Configuration.Test.Util
+namespace Autofac.Configuration.Test.Util;
+
+public class ReflectionExtensionsFixture
 {
-    public class ReflectionExtensionsFixture
+    [Fact]
+    public void TryGetDeclaringProperty_FindsPropertyFromSetterParameter()
     {
-        [Fact]
-        public void TryGetDeclaringProperty_FindsPropertyFromSetterParameter()
+        var expected = typeof(HasProperty).GetProperty("Property");
+        var setter = expected.GetSetMethod();
+        var valueParameter = setter.GetParameters()[0];
+        Assert.True(valueParameter.TryGetDeclaringProperty(out PropertyInfo actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void TryGetDeclaringProperty_FailsToFindProperty()
+    {
+        var valueParameter = typeof(HasProperty).GetMethod("NotSetter").GetParameters()[0];
+        Assert.False(valueParameter.TryGetDeclaringProperty(out PropertyInfo actual));
+        Assert.Null(actual);
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasProperty
+    {
+        public string NotSetter(string value)
         {
-            var expected = typeof(HasProperty).GetProperty("Property");
-            var setter = expected.GetSetMethod();
-            var valueParameter = setter.GetParameters()[0];
-            Assert.True(valueParameter.TryGetDeclaringProperty(out PropertyInfo actual));
-            Assert.Equal(expected, actual);
+            return value;
         }
 
-        [Fact]
-        public void TryGetDeclaringProperty_FailsToFindProperty()
-        {
-            var valueParameter = typeof(HasProperty).GetMethod("NotSetter").GetParameters()[0];
-            Assert.False(valueParameter.TryGetDeclaringProperty(out PropertyInfo actual));
-            Assert.Null(actual);
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasProperty
-        {
-            public string NotSetter(string value)
-            {
-                return value;
-            }
-
-            public string Property { get; set; }
-        }
+        public string Property { get; set; }
     }
 }

--- a/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
@@ -6,120 +6,119 @@ using System.Globalization;
 using System.Net;
 using Autofac.Configuration.Util;
 
-namespace Autofac.Configuration.Test.Util
+namespace Autofac.Configuration.Test.Util;
+
+public class TypeManipulationFixture
 {
-    public class TypeManipulationFixture
+    [Fact]
+    public void ChangeToCompatibleType_LooksForTryParseMethod()
     {
-        [Fact]
-        public void ChangeToCompatibleType_LooksForTryParseMethod()
-        {
-            var address = "127.0.0.1";
-            var value = TypeManipulation.ChangeToCompatibleType(address, typeof(IPAddress));
-            Assert.Equal(value, IPAddress.Parse(address));
-        }
+        var address = "127.0.0.1";
+        var value = TypeManipulation.ChangeToCompatibleType(address, typeof(IPAddress));
+        Assert.Equal(value, IPAddress.Parse(address));
+    }
 
-        [Fact]
-        public void ChangeToCompatibleType_UsesTypeConverterOnParameter()
-        {
-            var ctor = typeof(HasTypeConverterAttributes).GetConstructor(new Type[] { typeof(Convertible) });
-            var member = ctor.GetParameters().First();
-            var actual = TypeManipulation.ChangeToCompatibleType("25", typeof(Convertible), member) as Convertible;
-            Assert.NotNull(actual);
-            Assert.Equal(25, actual.Value);
-        }
+    [Fact]
+    public void ChangeToCompatibleType_UsesTypeConverterOnParameter()
+    {
+        var ctor = typeof(HasTypeConverterAttributes).GetConstructor(new Type[] { typeof(Convertible) });
+        var member = ctor.GetParameters().First();
+        var actual = TypeManipulation.ChangeToCompatibleType("25", typeof(Convertible), member) as Convertible;
+        Assert.NotNull(actual);
+        Assert.Equal(25, actual.Value);
+    }
 
-        [Fact]
-        public void ChangeToCompatibleType_UsesTypeConverterOnProperty()
-        {
-            var member = typeof(HasTypeConverterAttributes).GetProperty("Property");
-            var actual = TypeManipulation.ChangeToCompatibleType("25", typeof(Convertible), member) as Convertible;
-            Assert.NotNull(actual);
-            Assert.Equal(25, actual.Value);
-        }
+    [Fact]
+    public void ChangeToCompatibleType_UsesTypeConverterOnProperty()
+    {
+        var member = typeof(HasTypeConverterAttributes).GetProperty("Property");
+        var actual = TypeManipulation.ChangeToCompatibleType("25", typeof(Convertible), member) as Convertible;
+        Assert.NotNull(actual);
+        Assert.Equal(25, actual.Value);
+    }
 
-        [Fact]
-        public void ChangeToCompatibleType_NullReferenceType()
-        {
-            var actual = TypeManipulation.ChangeToCompatibleType(null, typeof(string));
-            Assert.Null(actual);
-        }
+    [Fact]
+    public void ChangeToCompatibleType_NullReferenceType()
+    {
+        var actual = TypeManipulation.ChangeToCompatibleType(null, typeof(string));
+        Assert.Null(actual);
+    }
 
-        [Fact]
-        public void ChangeToCompatibleType_NullValueType()
-        {
-            var actual = TypeManipulation.ChangeToCompatibleType(null, typeof(int));
-            Assert.Equal(0, actual);
-        }
+    [Fact]
+    public void ChangeToCompatibleType_NullValueType()
+    {
+        var actual = TypeManipulation.ChangeToCompatibleType(null, typeof(int));
+        Assert.Equal(0, actual);
+    }
 
-        [Fact]
-        public void ChangeToCompatibleType_NoConversionNeeded()
-        {
-            var actual = TypeManipulation.ChangeToCompatibleType(15, typeof(int));
-            Assert.Equal(15, actual);
-        }
+    [Fact]
+    public void ChangeToCompatibleType_NoConversionNeeded()
+    {
+        var actual = TypeManipulation.ChangeToCompatibleType(15, typeof(int));
+        Assert.Equal(15, actual);
+    }
 
-        [Theory]
-        [MemberData(nameof(ParsingCultures))]
-        public void ChangeToCompatibleType_UsesInvariantCulture(CultureInfo culture)
-        {
-            TestCulture.With(
-                culture,
-                () =>
-                {
-                    var actual = TypeManipulation.ChangeToCompatibleType("123.456", typeof(double));
-                    Assert.Equal(123.456, actual);
-                });
-        }
-
-        public static IEnumerable<object[]> ParsingCultures()
-        {
-            yield return new object[] { new CultureInfo("en-US") };
-            yield return new object[] { new CultureInfo("es-MX") };
-            yield return new object[] { new CultureInfo("it-IT") };
-            yield return new object[] { CultureInfo.InvariantCulture };
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class Convertible
-        {
-            public int Value { get; set; }
-        }
-
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class ConvertibleConverter : TypeConverter
-        {
-            public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+    [Theory]
+    [MemberData(nameof(ParsingCultures))]
+    public void ChangeToCompatibleType_UsesInvariantCulture(CultureInfo culture)
+    {
+        TestCulture.With(
+            culture,
+            () =>
             {
-                return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+                var actual = TypeManipulation.ChangeToCompatibleType("123.456", typeof(double));
+                Assert.Equal(123.456, actual);
+            });
+    }
+
+    public static IEnumerable<object[]> ParsingCultures()
+    {
+        yield return new object[] { new CultureInfo("en-US") };
+        yield return new object[] { new CultureInfo("es-MX") };
+        yield return new object[] { new CultureInfo("it-IT") };
+        yield return new object[] { CultureInfo.InvariantCulture };
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class Convertible
+    {
+        public int Value { get; set; }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class ConvertibleConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value == null)
+            {
+                return null;
             }
 
-            public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+            if (value is not string str)
             {
-                if (value == null)
-                {
-                    return null;
-                }
-
-                if (value is not string str)
-                {
-                    return base.ConvertFrom(context, culture, value);
-                }
-
-                var converter = TypeDescriptor.GetConverter(typeof(int));
-                return new Convertible { Value = (int)converter.ConvertFromString(context, culture, str) };
+                return base.ConvertFrom(context, culture, value);
             }
-        }
 
-        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
-        private class HasTypeConverterAttributes
+            var converter = TypeDescriptor.GetConverter(typeof(int));
+            return new Convertible { Value = (int)converter.ConvertFromString(context, culture, str) };
+        }
+    }
+
+    [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+    private class HasTypeConverterAttributes
+    {
+        public HasTypeConverterAttributes([TypeConverter(typeof(ConvertibleConverter))] Convertible parameter)
         {
-            public HasTypeConverterAttributes([TypeConverter(typeof(ConvertibleConverter))] Convertible parameter)
-            {
-                Property = parameter;
-            }
-
-            [TypeConverter(typeof(ConvertibleConverter))]
-            public Convertible Property { get; set; }
+            Property = parameter;
         }
+
+        [TypeConverter(typeof(ConvertibleConverter))]
+        public Convertible Property { get; set; }
     }
 }

--- a/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
@@ -1,14 +1,10 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using Autofac.Configuration.Util;
-using Xunit;
 
 namespace Autofac.Configuration.Test.Util
 {

--- a/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
@@ -83,12 +83,14 @@ namespace Autofac.Configuration.Test.Util
             yield return new object[] { CultureInfo.InvariantCulture };
         }
 
-        public class Convertible
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class Convertible
         {
             public int Value { get; set; }
         }
 
-        public class ConvertibleConverter : TypeConverter
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class ConvertibleConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
             {
@@ -102,7 +104,7 @@ namespace Autofac.Configuration.Test.Util
                     return null;
                 }
 
-                if (!(value is string str))
+                if (value is not string str)
                 {
                     return base.ConvertFrom(context, culture, value);
                 }
@@ -112,7 +114,8 @@ namespace Autofac.Configuration.Test.Util
             }
         }
 
-        public class HasTypeConverterAttributes
+        [SuppressMessage("CA1812", "CA1812", Justification = "Class instantiated through configuration.")]
+        private class HasTypeConverterAttributes
         {
             public HasTypeConverterAttributes([TypeConverter(typeof(ConvertibleConverter))] Convertible parameter)
             {


### PR DESCRIPTION
In the ongoing trend to move the builds to use .NET 6 with updated analyzers and all that... same thing for Autofac.Configuration. File-scoped namespaces, nullable annotations, .snupkg symbols, etc.