### PR TITLE
Technology refresh: update dependencies and target frameworks

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>7.0.0</Version>
+    <Version>8.0.0</Version>
     <SolutionName>Autofac.Configuration</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.414"
+    "version": "10.0.203"
   }
 }

--- a/src/Autofac.Configuration/Autofac.Configuration.csproj
+++ b/src/Autofac.Configuration/Autofac.Configuration.csproj
@@ -12,7 +12,7 @@
     <SignAssembly>true</SignAssembly>
     <NeutralLanguage>en-US</NeutralLanguage>
     <!-- Frameworks and language features -->
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -53,10 +53,10 @@
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
+    <PackageReference Include="Autofac" Version="9.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -262,8 +262,11 @@ public static class ConfigurationExtensions
         var subKeys = value.GetChildren().Select(sk => new Tuple<string, string?>(GetKeyName(sk.Key), sk.Value)).ToArray();
         if (subKeys.Length == 0)
         {
-            // No sub-keys indicates a scalar value.
-            return value.Value;
+            // No sub-keys indicates a scalar value. In M.E.Configuration 10+,
+            // empty JSON arrays produce Value="" with 0 children (previously
+            // Value=null). Treat null/empty as null to maintain backward
+            // compatibility for empty collections.
+            return string.IsNullOrEmpty(value.Value) ? null : value.Value;
         }
 
         if (subKeys.All(sk => int.TryParse(sk.Item1, out var parsed)))

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -200,7 +200,8 @@ public static class ConfigurationExtensions
             throw new ArgumentNullException(nameof(configuration));
         }
 
-        var typeName = configuration[key];
+        var typeName = configuration[key] ?? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeNotFound, key));
+
         var type = Type.GetType(typeName);
 
         if (type == null && defaultAssembly != null)
@@ -231,7 +232,7 @@ public static class ConfigurationExtensions
         {
             yield return int.TryParse(section.Key, out var _)
                 ? section
-                : throw new InvalidOperationException(string.Format(ConfigurationResources.CollectionMustBeOrderedByName, key, configurationSection.Path));
+                : throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, ConfigurationResources.CollectionMustBeOrderedByName, key, configurationSection.Path));
         }
     }
 

--- a/src/Autofac.Configuration/Core/ModuleRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ModuleRegistrar.cs
@@ -73,7 +73,7 @@ public class ModuleRegistrar : IModuleRegistrar
 
         var constructor = GetConstructorMatchingParameterNames(publicConstructors, parameterNames) ?? GetMostParametersConstructor(publicConstructors);
         var parameters = constructor.GetParameters()
-                                    .Select(p => parametersElement.GetSection(p.Name).Get(p.ParameterType))
+                                    .Select(p => parametersElement.GetSection(p.Name!).Get(p.ParameterType))
                                     .ToArray();
 
         var module = (IModule)constructor.Invoke(parameters);
@@ -85,10 +85,10 @@ public class ModuleRegistrar : IModuleRegistrar
         return module;
     }
 
-    private static ConstructorInfo GetConstructorMatchingParameterNames(ConstructorInfo[] constructors, IEnumerable<string> parameterNames)
+    private static ConstructorInfo? GetConstructorMatchingParameterNames(ConstructorInfo[] constructors, IEnumerable<string> parameterNames)
     {
         return constructors.Where(constructorInfo => constructorInfo.GetParameters()
-                                                                    .Select(pInfo => pInfo.Name)
+                                                                    .Select(pInfo => pInfo.Name!)
                                                                     .OrderBy(name => name)
                                                                     .SequenceEqual(parameterNames.OrderBy(s => s), StringComparer.OrdinalIgnoreCase))
                                                                     .FirstOrDefault();

--- a/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
@@ -23,13 +23,13 @@ internal class ConfiguredDictionaryParameter
 
     private class DictionaryTypeConverter : TypeConverter
     {
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             var instantiableType = GetInstantiableType(destinationType);
 
             if (value is ConfiguredDictionaryParameter castValue && instantiableType != null)
             {
-                var dictionary = (IDictionary)Activator.CreateInstance(instantiableType);
+                var dictionary = (IDictionary)Activator.CreateInstance(instantiableType)!;
                 var generics = instantiableType.GetGenericArguments();
 
                 if (castValue.Dictionary != null)
@@ -41,7 +41,7 @@ internal class ConfiguredDictionaryParameter
                             throw new FormatException(ConfigurationResources.DictionaryKeyMayNotBeNullOrEmpty);
                         }
 
-                        var convertedKey = TypeManipulation.ChangeToCompatibleType(item.Key, generics[0]);
+                        var convertedKey = TypeManipulation.ChangeToCompatibleType(item.Key, generics[0])!;
                         var convertedValue = TypeManipulation.ChangeToCompatibleType(item.Value, generics[1]);
 
                         dictionary.Add(convertedKey, convertedValue);
@@ -54,15 +54,16 @@ internal class ConfiguredDictionaryParameter
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return GetInstantiableType(destinationType) != null || base.CanConvertTo(context, destinationType);
         }
 
-        private static Type? GetInstantiableType(Type destinationType)
+        private static Type? GetInstantiableType(Type? destinationType)
         {
-            if (typeof(IDictionary).IsAssignableFrom(destinationType) ||
-                (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition())))
+            if (destinationType is not null &&
+                (typeof(IDictionary).IsAssignableFrom(destinationType) ||
+                (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition()))))
             {
                 var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(string), typeof(object) };
                 if (generics.Length != 2)

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -22,14 +22,14 @@ internal class ConfiguredListParameter
 
     private class ListTypeConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return GetInstantiableListType(destinationType) != null ||
                     GetInstantiableDictionaryType(destinationType) != null ||
                     base.CanConvertTo(context, destinationType);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, Type destinationType)
         {
             if (value is ConfiguredListParameter castValue)
             {
@@ -38,7 +38,7 @@ internal class ConfiguredListParameter
                 var instantiableType = GetInstantiableListType(destinationType);
                 if (instantiableType != null)
                 {
-                    var collection = (IList)Activator.CreateInstance(instantiableType);
+                    var collection = (IList)Activator.CreateInstance(instantiableType)!;
                     if (castValue.List != null)
                     {
                         var generics = instantiableType.GetGenericArguments();
@@ -59,13 +59,13 @@ internal class ConfiguredListParameter
                 instantiableType = GetInstantiableDictionaryType(destinationType);
                 if (instantiableType != null)
                 {
-                    var dictionary = (IDictionary)Activator.CreateInstance(instantiableType);
+                    var dictionary = (IDictionary)Activator.CreateInstance(instantiableType)!;
                     if (castValue.List != null)
                     {
                         var generics = instantiableType.GetGenericArguments();
                         for (var i = 0; i < castValue.List.Length; i++)
                         {
-                            var convertedKey = TypeManipulation.ChangeToCompatibleType(i, generics[0]);
+                            var convertedKey = TypeManipulation.ChangeToCompatibleType(i, generics[0])!;
                             var convertedValue = TypeManipulation.ChangeToCompatibleType(castValue.List[i], generics[1]);
 
                             dictionary.Add(convertedKey, convertedValue);
@@ -89,10 +89,11 @@ internal class ConfiguredListParameter
         /// <returns>
         /// A dictionary type where the key can be numeric.
         /// </returns>
-        private static Type? GetInstantiableDictionaryType(Type destinationType)
+        private static Type? GetInstantiableDictionaryType(Type? destinationType)
         {
-            if (typeof(IDictionary).IsAssignableFrom(destinationType) ||
-                (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition())))
+            if (destinationType is not null &&
+                (typeof(IDictionary).IsAssignableFrom(destinationType) ||
+                (destinationType.IsConstructedGenericType && typeof(IDictionary<,>).IsAssignableFrom(destinationType.GetGenericTypeDefinition()))))
             {
                 var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(int), typeof(object) };
                 if (generics.Length != 2)
@@ -119,9 +120,9 @@ internal class ConfiguredListParameter
         /// <returns>
         /// A list type compatible with the data values.
         /// </returns>
-        private static Type? GetInstantiableListType(Type destinationType)
+        private static Type? GetInstantiableListType(Type? destinationType)
         {
-            if (typeof(IEnumerable).IsAssignableFrom(destinationType))
+            if (destinationType is not null && typeof(IEnumerable).IsAssignableFrom(destinationType))
             {
                 var generics = destinationType.IsConstructedGenericType ? destinationType.GetGenericArguments() : new[] { typeof(object) };
                 if (generics.Length != 1)

--- a/src/Autofac.Configuration/Util/ReflectionExtensions.cs
+++ b/src/Autofac.Configuration/Util/ReflectionExtensions.cs
@@ -21,8 +21,8 @@ internal static class ReflectionExtensions
         var mi = pi.Member as MethodInfo;
         if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", StringComparison.Ordinal))
         {
-            prop = mi.DeclaringType.GetProperty(mi.Name.Substring(4));
-            return true;
+            prop = mi.DeclaringType?.GetProperty(mi.Name.Substring(4));
+            return prop != null;
         }
 
         prop = null;

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -132,7 +132,7 @@ internal class TypeManipulation
             if (parser != null)
             {
                 var parameters = new[] { value, null };
-                if ((bool)parser.Invoke(null, parameters))
+                if ((bool)parser.Invoke(null, parameters)!)
                 {
                     return parameters[1];
                 }
@@ -157,7 +157,7 @@ internal class TypeManipulation
     /// </exception>
     private static TypeConverter GetTypeConverterFromName(string converterTypeName)
     {
-        var converterType = Type.GetType(converterTypeName, true);
+        var converterType = Type.GetType(converterTypeName, true)!;
         return Activator.CreateInstance(converterType) is not TypeConverter converter
             ? throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConverterAttributeTypeNotConverter, converterTypeName))
             : converter;

--- a/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
+++ b/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -48,9 +48,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- Update .NET SDK from 8.0.414 to 10.0.203
- Update package version from 7.0.0 to 8.0.0
- Add net10.0 and net8.0 target frameworks (keeping netstandard2.1 and netstandard2.0)
- Update Autofac from 8.0.0 to 9.1.0
- Update Microsoft.Extensions.Configuration from 8.0.0 to 10.0.8
- Update Microsoft.Extensions.Configuration.Binder from 8.0.2 to 10.0.8
- Update Microsoft.SourceLink.GitHub from 8.0.0 to 10.0.300
- Update test project to net10.0;net8.0
- Fix nullability annotations for compatibility with Autofac 9.1.0
- Fix empty collection handling for M.E.Configuration 10.x behavioral change

## Changes
- **global.json**: SDK 8.0.414 → 10.0.203
- **default.proj**: Version 7.0.0 → 8.0.0
- **Source project**: 
  - TargetFrameworks: `netstandard2.1;netstandard2.0` → `net10.0;net8.0;netstandard2.1;netstandard2.0`
  - Autofac: 8.0.0 → 9.1.0
  - Microsoft.Extensions.Configuration: 8.0.0 → 10.0.8
  - Microsoft.Extensions.Configuration.Binder: 8.0.2 → 10.0.8
  - Microsoft.SourceLink.GitHub: 8.0.0 → 10.0.300
- **Test project**: 
  - TargetFrameworks: net8.0 → net10.0;net8.0
  - Microsoft.Extensions.Configuration*: 8.0.0 → 10.0.8
- **Code fixes**:
  - Updated nullability annotations in TypeConverter implementations, ReflectionExtensions, ConfigurationExtensions, ModuleRegistrar, and TypeManipulation to match Autofac 9.1.0 signatures
  - Fixed `GetConfiguredParameterValue` to handle M.E.Configuration 10.x change where empty JSON arrays (`[]`) now produce `Value=""` with 0 children instead of `Value=null`

## Test plan
- [x] Build succeeds with zero warnings
- [x] All 92 tests pass on both net8.0 and net10.0
- [x] Packages restore successfully
- [x] All target frameworks build successfully