### PR TITLE
Add SonarAnalyzer.CSharp and tighten Roslyn analyzer rules

### DIFF
--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -4,6 +4,8 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
     <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
     <!-- Avoid excessive complexity (must be explicitly enabled). -->
@@ -44,6 +46,8 @@
     <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
     <Rule Id="S3267" Action="None" />
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - Autofac uses non-standard dispose patterns for container lifecycle. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <Rule Id="S6418" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -32,6 +32,8 @@
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <!-- "Sonar Way" rules to match SonarQube scans. -->
     <Rule Id="S107" Action="Warning" />
+    <!-- Do not use obsolete members - Autofac maintains deprecated APIs for backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1192" Action="Warning" />
     <Rule Id="S1313" Action="Warning" />
     <Rule Id="S2259" Action="Warning" />

--- a/build/Source.ruleset
+++ b/build/Source.ruleset
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac source assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Implement standard exception constructors - not all of the exception constructors are desired. -->
     <Rule Id="CA1032" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -12,22 +12,40 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
+    <!-- Use ArgumentNullException.ThrowIfNull - not available in netstandard. -->
     <Rule Id="CA1510" Action="None" />
-    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ArgumentOutOfRangeException.ThrowIfNegative - not available below net8.0. -->
     <Rule Id="CA1512" Action="None" />
-    <!-- Use ObjectDisposedException.ThrowIf - this isn't available until we stop targeting anything below net8.0. -->
+    <!-- Use ObjectDisposedException.ThrowIf - not available below net8.0. -->
     <Rule Id="CA1513" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
+    <!-- Change names to avoid reserved word overlaps - would break public API. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this isn't available until we stop targeting netstandard, and we only String.Format when throwing exceptions so the work/complexity isn't justified to increase perf just for those situations. -->
+    <!-- Cache a CompositeFormat - not available in netstandard. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - many aren't available in earlier frameworks; and we do a lot of reflection work in Autofac. -->
+    <!-- Prefer generic overloads - conflicts with reflection work in Autofac. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- "Sonar Way" rules to match SonarQube scans. -->
+    <Rule Id="S107" Action="Warning" />
+    <Rule Id="S1192" Action="Warning" />
+    <Rule Id="S1313" Action="Warning" />
+    <Rule Id="S2259" Action="Warning" />
+    <Rule Id="S2583" Action="Warning" />
+    <Rule Id="S2589" Action="Warning" />
+    <!-- Verify reflection accessibility bypass - DI containers do extensive reflection by design. -->
+    <Rule Id="S3011" Action="None" />
+    <!-- Loops should use LINQ - DI container hot paths intentionally avoid LINQ allocations. -->
+    <Rule Id="S3267" Action="None" />
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <Rule Id="S6418" Action="Warning" />
+    <Rule Id="S6444" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -55,6 +55,8 @@
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
     <!-- Remove unused private members - reflection tests need non-public members. -->
+    <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
+    <Rule Id="S1133" Action="None" />
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -42,6 +42,8 @@
     <Rule Id="CA2234" Action="None" />
     <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
+    <!-- Nested types should not be visible - test scenario classes use nested types extensively. -->
+    <Rule Id="CA1034" Action="None" />
     <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
   </Rules>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -23,6 +23,10 @@
     <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
     <!-- Internal class that appears to never be instantiated - false positives from DI. -->
+    <!-- Identifiers should not have incorrect suffix - test classes use Impl, Handler, etc. -->
+    <Rule Id="CA1711" Action="None" />
+    <!-- Property names should not match get methods - aggregate service tests intentionally test both. -->
+    <Rule Id="CA1721" Action="None" />
     <Rule Id="CA1812" Action="None" />
     <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
@@ -55,6 +59,8 @@
     <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
     <Rule Id="S1075" Action="None" />
     <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <!-- Sections of code should not be commented out - test files may retain commented examples. -->
+    <Rule Id="S125" Action="None" />
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -39,6 +39,8 @@
     <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
     <!-- Implement serialization constructors - false positive in .NET Core. -->
+    <!-- Do not raise reserved exception types - tests use generic exceptions for simulation. -->
+    <Rule Id="CA2201" Action="None" />
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,6 +6,8 @@
     <Rule Id="CA1031" Action="None" />
     <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
+    <!-- Implement IDisposable correctly (must be explicitly enabled). -->
+    <Rule Id="CA1063" Action="Warning" />
     <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
@@ -54,9 +56,9 @@
     <Rule Id="S1118" Action="None" />
     <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
     <Rule Id="S1215" Action="None" />
-    <!-- Remove unused private members - reflection tests need non-public members. -->
     <!-- Do not use obsolete members - tests exercise deprecated APIs to verify backward compat. -->
     <Rule Id="S1133" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
     <Rule Id="S1144" Action="None" />
     <!-- Empty method bodies - test stubs often have no-op implementations. -->
     <Rule Id="S1186" Action="None" />
@@ -80,6 +82,8 @@
     <Rule Id="S2335" Action="None" />
     <!-- Cognitive complexity (must be explicitly enabled). -->
     <Rule Id="S3776" Action="Warning" />
+    <!-- IDisposable pattern - test dispose implementations are intentionally simplified. -->
+    <Rule Id="S3881" Action="None" />
     <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
     <Rule Id="S4456" Action="None" />
     <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,16 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac test assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
-  <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Avoid excessive parameters on generic types (must be explicitly enabled). -->
-    <Rule Id="CA1005" Action="Warning" />
-    <!-- Don't catch general exceptions - test scenarios sometimes require general exception handling. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- Don't catch general exceptions - test scenarios sometimes require it. -->
     <Rule Id="CA1031" Action="None" />
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
-    <Rule Id="CA1032" Action="None" />
-    <!-- Avoid empty interfaces - in unit tests for service resolution, this happens a lot. -->
+    <!-- Avoid empty interfaces - happens a lot in unit tests for service resolution. -->
     <Rule Id="CA1040" Action="None" />
-    <!-- Do not pass literals as localized parameters  - tests don't need to localize. -->
+    <!-- Do not pass literals as localized parameters - tests don't need to localize. -->
     <Rule Id="CA1303" Action="None" />
     <!-- Avoid excessive inheritance (must be explicitly enabled). -->
     <Rule Id="CA1501" Action="Warning" />
@@ -20,36 +16,78 @@
     <Rule Id="CA1505" Action="Warning" />
     <!-- Avoid excessive class coupling (must be explicitly enabled). -->
     <Rule Id="CA1506" Action="Warning" />
-    <!-- Use ArgumentNullException.ThrowIfNull - this isn't available until we stop targeting netstandard. -->
-    <Rule Id="CA1510" Action="None" />
-    <!-- Make API types internal - causes problems with tests and test assemblies. -->
+    <!-- Make API types internal - causes problems with tests. -->
     <Rule Id="CA1515" Action="None" />
-    <!-- Remove the underscores from member name - unit test scenarios may use underscores. -->
+    <!-- Remove underscores from member name - test naming conventions use underscore. -->
     <Rule Id="CA1707" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
-    <Rule Id="CA1716" Action="None" />
-    <!-- Internal class that appears to never be instantiated - lots of false positives here because they're test stubs created by Autofac registrations. -->
+    <!-- Internal class that appears to never be instantiated - false positives from DI. -->
     <Rule Id="CA1812" Action="None" />
-    <!-- Change Dispose() to call GC.SuppressFinalize - in tests we don't really care and it can impact readability. -->
+    <!-- Change Dispose() to call GC.SuppressFinalize - unimportant in tests. -->
     <Rule Id="CA1816" Action="None" />
-    <!-- Mark members static - test methods may not access member data but also can't be static. -->
+    <!-- Mark members static - test methods may not access member data. -->
     <Rule Id="CA1822" Action="None" />
-    <!-- Seal internal types for performance - in tests we don't really care and it gets painful to enforce. -->
+    <!-- Use the LoggerMessage delegates - noise in tests, performance irrelevant. -->
+    <Rule Id="CA1848" Action="None" />
+    <!-- Seal internal types - unimportant in tests. -->
     <Rule Id="CA1852" Action="None" />
-    <!-- Prefer static readonly fields over constant array arguments - constant array arguments happen a lot in unit tests for assertions and test setup. -->
+    <!-- Prefer static readonly fields over constant arrays - happens in test setup. -->
     <Rule Id="CA1861" Action="None" />
-    <!-- Cache a CompositeFormat object for use in String.Format - this makes unit tests harder to read, and performance isn't an issue. -->
+    <!-- Cache a CompositeFormat - makes tests harder to read. -->
     <Rule Id="CA1863" Action="None" />
-    <!-- Call ConfigureAwait on tasks - you shouldn't do this in unit test libraries; XUnit has an opposite analyzer. -->
+    <!-- Call ConfigureAwait - shouldn't in test libraries; XUnit has opposing analyzer. -->
     <Rule Id="CA2007" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core. -->
+    <!-- Implement serialization constructors - false positive in .NET Core. -->
     <Rule Id="CA2229" Action="None" />
     <!-- Use Uri instead of string parameters - strings are easier for testing. -->
     <Rule Id="CA2234" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core. -->
+    <!-- Mark ISerializable types with SerializableAttribute - false positive in .NET Core. -->
     <Rule Id="CA2237" Action="None" />
-    <!-- Prefer generic overloads to using Type parameters - we do a lot of reflection work in Autofac that needs to be tested. -->
+    <!-- Prefer generic overloads - reflection work in Autofac needs to be tested. -->
     <Rule Id="CA2263" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+    <!-- Don't use hardcoded paths or URIs - needed in several test cases. -->
+    <Rule Id="S1075" Action="None" />
+    <!-- Utility class should not be instantiated - test fixture classes with nested tests can't be static. -->
+    <Rule Id="S1118" Action="None" />
+    <!-- Don't call GC.Collect - required for weak reference and disposal tests. -->
+    <Rule Id="S1215" Action="None" />
+    <!-- Remove unused private members - reflection tests need non-public members. -->
+    <Rule Id="S1144" Action="None" />
+    <!-- Empty method bodies - test stubs often have no-op implementations. -->
+    <Rule Id="S1186" Action="None" />
+    <!-- Remove unused method parameters - reflection tests declare parameters not used in the body. -->
+    <Rule Id="S1172" Action="None" />
+    <!-- Remove empty class - test stubs for DI resolution don't need implementation. -->
+    <Rule Id="S2094" Action="None" />
+    <!-- Make member static - test fixture members may not access instance data. -->
+    <Rule Id="S2325" Action="None" />
+    <!-- Remove unused type parameters - used in reflection testing. -->
+    <Rule Id="S2326" Action="None" />
+    <!-- Write-only properties - reflection tests verify property setter behavior. -->
+    <Rule Id="S2376" Action="None" />
+    <!-- Classes with only private constructors - reflection tests verify inaccessible constructors. -->
+    <Rule Id="S3453" Action="None" />
+    <!-- Remove unassigned auto-property - reflection tests verify non-public property behavior. -->
+    <Rule Id="S3459" Action="None" />
+    <!-- Complete the TODO - acceptable in tests for backlog items. -->
+    <Rule Id="S1135" Action="None" />
+    <!-- Make instance property static - false positives in data/document types. -->
+    <Rule Id="S2335" Action="None" />
+    <!-- Cognitive complexity (must be explicitly enabled). -->
+    <Rule Id="S3776" Action="Warning" />
+    <!-- Split method for params check + iterator - overly prescriptive for our patterns. -->
+    <Rule Id="S4456" Action="None" />
+    <!-- Don't use Thread.Sleep - required for concurrency and timing tests. -->
+    <Rule Id="S2925" Action="None" />
+    <!-- NSubstitute mock verification is complete without property access. -->
+    <Rule Id="S2970" Action="None" />
+    <!-- Fields only assigned in constructor - needed to prevent optimization in reflection tests. -->
+    <Rule Id="S4487" Action="None" />
+    <!-- Set route attributes at top of controller - false positive. -->
+    <Rule Id="S6934" Action="None" />
+    <!-- Use async dispose - sync dispose tests are intentional. -->
+    <Rule Id="S6966" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <!-- Prefix local calls with this. -->
@@ -58,11 +96,11 @@
     <Rule Id="SA1121" Action="None" />
     <!-- Use String.Empty instead of "". -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Enforce order of class members by member type - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by member type. -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of class members by visibility. -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of static vs. non-static members - sometimes putting test classes/data by the test helps. -->
+    <!-- Enforce order of static vs. non-static members. -->
     <Rule Id="SA1204" Action="None" />
     <!-- Fields can't start with underscore. -->
     <Rule Id="SA1309" Action="None" />
@@ -82,6 +120,13 @@
     <Rule Id="SA1618" Action="None" />
     <!-- Don't copy/paste documentation. -->
     <Rule Id="SA1625" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="xUnit" RuleNamespace="xUnit">
+    <!-- Use Assert.Single when there's only one collection entry. -->
+    <Rule Id="xUnit2023" Action="Warning" />
+  </Rules>
+  <!-- IDE rules for test assemblies. -->
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
     <!-- Private member is unused - tests for reflection require members that may not get used. -->
     <Rule Id="IDE0051" Action="None" />
     <!-- Private member assigned value never read - tests for reflection require values that may not get used. -->

--- a/src/Autofac.Configuration/Autofac.Configuration.csproj
+++ b/src/Autofac.Configuration/Autofac.Configuration.csproj
@@ -62,6 +62,10 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemDefinitionGroup>
     <EmbeddedResource>

--- a/src/Autofac.Configuration/Core/ComponentRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ComponentRegistrar.cs
@@ -99,7 +99,7 @@ public class ComponentRegistrar : IComponentRegistrar
         {
             // "name" is a special reserved key in the XML configuration source
             // that enables ordinal collections. To support both JSON and XML
-            // sources, we can't use "name" as the keyed service identifier;
+            // sources, we can't use "name" as the keyed service identifier -
             // instead, it must be "key."
             var serviceType = serviceDefinition.GetType("type", defaultAssembly);
             var serviceKey = serviceDefinition["key"];

--- a/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
+++ b/src/Autofac.Configuration/Core/ConfigurationExtensions.cs
@@ -269,7 +269,7 @@ public static class ConfigurationExtensions
             return string.IsNullOrEmpty(value.Value) ? null : value.Value;
         }
 
-        if (subKeys.All(sk => int.TryParse(sk.Item1, out var parsed)))
+        if (subKeys.All(sk => int.TryParse(sk.Item1, out var _)))
         {
             var i = 0;
             var isList = true;

--- a/src/Autofac.Configuration/Core/ModuleRegistrar.cs
+++ b/src/Autofac.Configuration/Core/ModuleRegistrar.cs
@@ -87,11 +87,10 @@ public class ModuleRegistrar : IModuleRegistrar
 
     private static ConstructorInfo? GetConstructorMatchingParameterNames(ConstructorInfo[] constructors, IEnumerable<string> parameterNames)
     {
-        return constructors.Where(constructorInfo => constructorInfo.GetParameters()
+        return constructors.FirstOrDefault(constructorInfo => constructorInfo.GetParameters()
                                                                     .Select(pInfo => pInfo.Name!)
                                                                     .OrderBy(name => name)
-                                                                    .SequenceEqual(parameterNames.OrderBy(s => s), StringComparer.OrdinalIgnoreCase))
-                                                                    .FirstOrDefault();
+                                                                    .SequenceEqual(parameterNames.OrderBy(s => s), StringComparer.OrdinalIgnoreCase));
     }
 
     private static ConstructorInfo GetMostParametersConstructor(ConstructorInfo[] constructors)

--- a/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredDictionaryParameter.cs
@@ -21,7 +21,7 @@ internal class ConfiguredDictionaryParameter
         get; set;
     }
 
-    private class DictionaryTypeConverter : TypeConverter
+    private sealed class DictionaryTypeConverter : TypeConverter
     {
         public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -31,52 +31,68 @@ internal class ConfiguredListParameter
 
         public override object? ConvertTo(ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, Type destinationType)
         {
-            if (value is ConfiguredListParameter castValue)
+            if (value is not ConfiguredListParameter castValue)
             {
-                // 99% of the time this type of parameter will be associated
-                // with an ordinal list - List<T> or T[] sort of thing...
-                var instantiableType = GetInstantiableListType(destinationType);
-                if (instantiableType != null)
-                {
-                    var collection = (IList)Activator.CreateInstance(instantiableType)!;
-                    if (castValue.List != null)
-                    {
-                        var generics = instantiableType.GetGenericArguments();
-                        foreach (var item in castValue.List)
-                        {
-                            collection.Add(TypeManipulation.ChangeToCompatibleType(item, generics[0]));
-                        }
-                    }
-
-                    return collection;
-                }
-
-                // ...but there is a very small chance this is a Dictionary<int, T> where
-                // the keys are all 0-based and ordinal. This clause checks for
-                // that one edge case. We should only have gotten here if
-                // ConfigurationExtensions.GetConfiguredParameterValue saw
-                // a 0-based configuration dictionary.
-                instantiableType = GetInstantiableDictionaryType(destinationType);
-                if (instantiableType != null)
-                {
-                    var dictionary = (IDictionary)Activator.CreateInstance(instantiableType)!;
-                    if (castValue.List != null)
-                    {
-                        var generics = instantiableType.GetGenericArguments();
-                        for (var i = 0; i < castValue.List.Length; i++)
-                        {
-                            var convertedKey = TypeManipulation.ChangeToCompatibleType(i, generics[0])!;
-                            var convertedValue = TypeManipulation.ChangeToCompatibleType(castValue.List[i], generics[1]);
-
-                            dictionary.Add(convertedKey, convertedValue);
-                        }
-                    }
-
-                    return dictionary;
-                }
+                return base.ConvertTo(context, culture, value, destinationType);
             }
 
-            return base.ConvertTo(context, culture, value, destinationType);
+            return ConvertConfiguredList(castValue, destinationType) ?? base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        private static object? ConvertConfiguredList(ConfiguredListParameter configuredList, Type destinationType)
+        {
+            return ConvertToInstantiableList(configuredList, destinationType) ?? ConvertToInstantiableDictionary(configuredList, destinationType);
+        }
+
+        private static object? ConvertToInstantiableList(ConfiguredListParameter configuredList, Type destinationType)
+        {
+            // 99% of the time this type of parameter will be associated
+            // with an ordinal list - List<T> or T[] sort of thing.
+            var instantiableType = GetInstantiableListType(destinationType);
+            if (instantiableType == null)
+            {
+                return null;
+            }
+
+            var collection = (IList)Activator.CreateInstance(instantiableType)!;
+            if (configuredList.List == null)
+            {
+                return collection;
+            }
+
+            var elementType = instantiableType.GetGenericArguments()[0];
+            foreach (var item in configuredList.List)
+            {
+                collection.Add(TypeManipulation.ChangeToCompatibleType(item, elementType));
+            }
+
+            return collection;
+        }
+
+        private static object? ConvertToInstantiableDictionary(ConfiguredListParameter configuredList, Type destinationType)
+        {
+            // Rare edge case for Dictionary<int, T>-style ordinal keys.
+            var instantiableType = GetInstantiableDictionaryType(destinationType);
+            if (instantiableType == null)
+            {
+                return null;
+            }
+
+            var dictionary = (IDictionary)Activator.CreateInstance(instantiableType)!;
+            if (configuredList.List == null)
+            {
+                return dictionary;
+            }
+
+            var generics = instantiableType.GetGenericArguments();
+            for (var i = 0; i < configuredList.List.Length; i++)
+            {
+                var convertedKey = TypeManipulation.ChangeToCompatibleType(i, generics[0])!;
+                var convertedValue = TypeManipulation.ChangeToCompatibleType(configuredList.List[i], generics[1]);
+                dictionary.Add(convertedKey, convertedValue);
+            }
+
+            return dictionary;
         }
 
         /// <summary>

--- a/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
+++ b/src/Autofac.Configuration/Util/ConfiguredListParameter.cs
@@ -20,7 +20,7 @@ internal class ConfiguredListParameter
         get; set;
     }
 
-    private class ListTypeConverter : TypeConverter
+    private sealed class ListTypeConverter : TypeConverter
     {
         public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {

--- a/src/Autofac.Configuration/Util/TypeManipulation.cs
+++ b/src/Autofac.Configuration/Util/TypeManipulation.cs
@@ -10,7 +10,7 @@ namespace Autofac.Configuration.Util;
 /// <summary>
 /// Utilities for converting string configuration values into strongly-typed objects.
 /// </summary>
-internal class TypeManipulation
+internal static class TypeManipulation
 {
     /// <summary>
     /// Converts an object to a type compatible with a given parameter.
@@ -97,49 +97,105 @@ internal class TypeManipulation
             return value;
         }
 
-        TypeConverter converter;
-
-        // Try to get custom type converter information.
-        if (converterAttribute != null && !string.IsNullOrEmpty(converterAttribute.ConverterTypeName))
+        if (TryConvertWithKnownStrategies(value, destinationType, converterAttribute, out var converted))
         {
-            converter = GetTypeConverterFromName(converterAttribute.ConverterTypeName);
-            if (converter.CanConvertFrom(value.GetType()))
-            {
-                return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
-            }
-        }
-
-        // If there's not a custom converter specified via attribute, try for a default.
-        converter = TypeDescriptor.GetConverter(value.GetType());
-        if (converter.CanConvertTo(destinationType))
-        {
-            return converter.ConvertTo(null, CultureInfo.InvariantCulture, value, destinationType);
-        }
-
-        // Try explicit opposite conversion.
-        converter = TypeDescriptor.GetConverter(destinationType);
-        if (converter.CanConvertFrom(value.GetType()))
-        {
-            return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
-        }
-
-        // Try a TryParse method.
-        if (value is string)
-        {
-            // Some types in later frameworks have string TryParse and ReadOnlySpan<char> TryParse
-            // so they result in an AmbiguousMatchException unless we specify.
-            var parser = destinationType.GetMethod("TryParse", BindingFlags.Static | BindingFlags.Public, null, CallingConventions.Standard, new Type[] { typeof(string), destinationType.MakeByRefType() }, null);
-            if (parser != null)
-            {
-                var parameters = new[] { value, null };
-                if ((bool)parser.Invoke(null, parameters)!)
-                {
-                    return parameters[1];
-                }
-            }
+            return converted;
         }
 
         throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ConfigurationResources.TypeConversionUnsupported, value.GetType(), destinationType));
+    }
+
+    private static bool TryConvertWithKnownStrategies(object value, Type destinationType, TypeConverterAttribute? converterAttribute, out object? converted)
+    {
+        if (TryConvertWithCustomConverter(value, converterAttribute, out converted))
+        {
+            return true;
+        }
+
+        if (TryConvertWithSourceConverter(value, destinationType, out converted))
+        {
+            return true;
+        }
+
+        if (TryConvertWithDestinationConverter(value, destinationType, out converted))
+        {
+            return true;
+        }
+
+        return TryConvertWithTryParse(value, destinationType, out converted);
+    }
+
+    private static bool TryConvertWithCustomConverter(object value, TypeConverterAttribute? converterAttribute, out object? converted)
+    {
+        converted = null;
+
+        if (converterAttribute == null || string.IsNullOrEmpty(converterAttribute.ConverterTypeName))
+        {
+            return false;
+        }
+
+        var converter = GetTypeConverterFromName(converterAttribute.ConverterTypeName);
+        if (!converter.CanConvertFrom(value.GetType()))
+        {
+            return false;
+        }
+
+        converted = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+        return true;
+    }
+
+    private static bool TryConvertWithSourceConverter(object value, Type destinationType, out object? converted)
+    {
+        converted = null;
+
+        var converter = TypeDescriptor.GetConverter(value.GetType());
+        if (!converter.CanConvertTo(destinationType))
+        {
+            return false;
+        }
+
+        converted = converter.ConvertTo(null, CultureInfo.InvariantCulture, value, destinationType);
+        return true;
+    }
+
+    private static bool TryConvertWithDestinationConverter(object value, Type destinationType, out object? converted)
+    {
+        converted = null;
+
+        var converter = TypeDescriptor.GetConverter(destinationType);
+        if (!converter.CanConvertFrom(value.GetType()))
+        {
+            return false;
+        }
+
+        converted = converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+        return true;
+    }
+
+    private static bool TryConvertWithTryParse(object value, Type destinationType, out object? converted)
+    {
+        converted = null;
+        if (value is not string)
+        {
+            return false;
+        }
+
+        // Some types in later frameworks have string TryParse and ReadOnlySpan<char> TryParse
+        // so they result in an AmbiguousMatchException unless we specify.
+        var parser = destinationType.GetMethod("TryParse", BindingFlags.Static | BindingFlags.Public, null, CallingConventions.Standard, new Type[] { typeof(string), destinationType.MakeByRefType() }, null);
+        if (parser == null)
+        {
+            return false;
+        }
+
+        var parameters = new[] { value, null };
+        if (!(bool)parser.Invoke(null, parameters)!)
+        {
+            return false;
+        }
+
+        converted = parameters[1];
+        return true;
     }
 
     /// <summary>

--- a/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
+++ b/test/Autofac.Configuration.Test/Autofac.Configuration.Test.csproj
@@ -56,6 +56,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.27.0.140913">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ComponentRegistrarFixture.cs
@@ -10,6 +10,7 @@ namespace Autofac.Configuration.Test.Core;
 public class ComponentRegistrarFixture
 {
     [Fact]
+    [SuppressMessage("S1244", "S1244", Justification = "Exact equality is intentional for parsed configuration values.")]
     public void RegisterConfiguredComponents_AllowsMultipleRegistrationsOfSameType()
     {
         var builder = EmbeddedConfiguration.ConfigureContainerWithJson("ComponentRegistrar_SameTypeRegisteredMultipleTimes.json");

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensionsFixture.cs
@@ -101,8 +101,8 @@ public class ConfigurationExtensionsFixture
     public void GetParameters_ListParameterPopulated()
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableParameter).FullName).First();
-        var objectParameter = typeof(HasEnumerableParameter).GetConstructors().First().GetParameters().First(pi => pi.Name == "list");
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasEnumerableParameter).FullName);
+        var objectParameter = typeof(HasEnumerableParameter).GetConstructors()[0].GetParameters().First(pi => pi.Name == "list");
         var provider = (Func<object>)null;
         var parameter = component.GetParameters("parameters").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(objectParameter, new ContainerBuilder().Build(), out provider));
         Assert.NotNull(parameter);
@@ -137,8 +137,8 @@ public class ConfigurationExtensionsFixture
     public void GetParameters_SimpleParameters(string parameterName, object expectedValue)
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName).First();
-        var objectParameter = typeof(HasSimpleParametersAndProperties).GetConstructors().First().GetParameters().First(pi => pi.Name == parameterName);
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName);
+        var objectParameter = typeof(HasSimpleParametersAndProperties).GetConstructors()[0].GetParameters().First(pi => pi.Name == parameterName);
         var provider = (Func<object>)null;
         var parameter = component.GetParameters("parameters").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(objectParameter, new ContainerBuilder().Build(), out provider));
         Assert.NotNull(parameter);
@@ -150,10 +150,10 @@ public class ConfigurationExtensionsFixture
     public void GetProperties_DictionaryPropertyEmpty()
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName).First();
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName);
         var property = typeof(HasDictionaryProperty).GetProperty("Empty");
         var provider = (Func<object>)null;
-        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters()[0], new ContainerBuilder().Build(), out provider));
 
         // In older .NET there was a gotcha in ConfigurationModel - if the
         // list/dictionary was empty then configuration wouldn't see it or add
@@ -166,10 +166,10 @@ public class ConfigurationExtensionsFixture
     public void GetProperties_DictionaryPropertyPopulated()
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName).First();
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasDictionaryProperty).FullName);
         var property = typeof(HasDictionaryProperty).GetProperty("Populated");
         var provider = (Func<object>)null;
-        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters()[0], new ContainerBuilder().Build(), out provider));
         Assert.NotNull(parameter);
         Assert.NotNull(provider);
         var value = provider();
@@ -215,10 +215,10 @@ public class ConfigurationExtensionsFixture
     public void GetProperties_ListPropertyEmpty()
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName).First();
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName);
         var property = typeof(HasEnumerableProperty).GetProperty("Empty");
         var provider = (Func<object>)null;
-        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters()[0], new ContainerBuilder().Build(), out provider));
 
         // In older .NET there was a gotcha in ConfigurationModel - if the
         // list/dictionary was empty then configuration wouldn't see it or add
@@ -231,10 +231,10 @@ public class ConfigurationExtensionsFixture
     public void GetProperties_ListPropertyPopulated()
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName).First();
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasEnumerableProperty).FullName);
         var property = typeof(HasEnumerableProperty).GetProperty("Populated");
         var provider = (Func<object>)null;
-        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters()[0], new ContainerBuilder().Build(), out provider));
         Assert.NotNull(parameter);
         Assert.NotNull(provider);
         Assert.Equal(new List<double> { 1.234, 2.345 }, provider());
@@ -267,10 +267,10 @@ public class ConfigurationExtensionsFixture
     public void GetProperties_SimpleProperties(string propertyName, object expectedValue)
     {
         var config = EmbeddedConfiguration.LoadJson("ConfigurationExtensions_Parameters.json");
-        var component = config.GetSection("components").GetChildren().Where(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName).First();
+        var component = config.GetSection("components").GetChildren().First(kvp => kvp["type"] == typeof(HasSimpleParametersAndProperties).FullName);
         var property = typeof(HasSimpleParametersAndProperties).GetProperties().First(pi => pi.Name == propertyName);
         var provider = (Func<object>)null;
-        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters().First(), new ContainerBuilder().Build(), out provider));
+        var parameter = component.GetProperties("properties").Cast<Parameter>().FirstOrDefault(rp => rp.CanSupplyValue(property.SetMethod.GetParameters()[0], new ContainerBuilder().Build(), out provider));
         Assert.NotNull(parameter);
         Assert.NotNull(provider);
         Assert.Equal(expectedValue, provider());

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
@@ -264,7 +264,7 @@ public class ConfigurationExtensions_EnumerableParametersFixture
             List = new List<string>();
         }
 
-        public L(IList<string> list = null)
+        public L(IList<string> list)
         {
             List = list;
         }

--- a/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
+++ b/test/Autofac.Configuration.Test/Core/ConfigurationExtensions_EnumerableParametersFixture.cs
@@ -310,7 +310,8 @@ public class ConfigurationExtensions_EnumerableParametersFixture
         var poco = container.Resolve<M>();
 
         // Val2 is dropped from the configuration when it's parsed.
-        Assert.Collection(poco.List, v => Assert.Equal("Val1", v));
+        var item = Assert.Single(poco.List);
+        Assert.Equal("Val1", item);
     }
 
     public static IEnumerable<object[]> ParsingCultures()

--- a/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
+++ b/test/Autofac.Configuration.Test/Util/TypeManipulationFixture.cs
@@ -22,7 +22,7 @@ public class TypeManipulationFixture
     public void ChangeToCompatibleType_UsesTypeConverterOnParameter()
     {
         var ctor = typeof(HasTypeConverterAttributes).GetConstructor(new Type[] { typeof(Convertible) });
-        var member = ctor.GetParameters().First();
+        var member = ctor.GetParameters()[0];
         var actual = TypeManipulation.ChangeToCompatibleType("25", typeof(Convertible), member) as Convertible;
         Assert.NotNull(actual);
         Assert.Equal(25, actual.Value);


### PR DESCRIPTION
## Summary

- Adds SonarAnalyzer.CSharp (10.27.0.140913) to all projects
- Introduces unified `build/Source.ruleset` and `build/Test.ruleset` with consistent analyzer configuration
- Fixes all actionable analyzer warnings (code changes per-rule in individual commits)
- Disables rules that are false positives or inapplicable for this project's patterns

## Changes

- **New analyzer**: SonarAnalyzer.CSharp added via PackageReference with PrivateAssets=all
- **Rulesets**: Unified Source.ruleset and Test.ruleset covering Microsoft, Sonar, StyleCop, and xUnit analyzers
- **Code fixes**: Various warning fixes committed individually by rule ID for easy review
- **Zero warnings**: Build completes with no analyzer warnings

## Test plan

- [ ] CI build passes (zero errors, zero warnings)
- [ ] All existing tests pass
- [ ] No public API changes (verify with `dotnet format --verify-no-changes`)